### PR TITLE
docs: add VitePress site and update README

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,58 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build VitePress docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: docs/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: docs
+
+      - name: Build docs
+        run: npx vitepress build
+        working-directory: docs
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/.vitepress/dist
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,8 @@ poetry.lock
 *PRD.md
 task.md
 
+# VitePress / Node
+docs/node_modules/
+docs/.vitepress/dist/
+docs/.vitepress/cache/
+

--- a/README.md
+++ b/README.md
@@ -4,68 +4,88 @@
     <img src="https://raw.githubusercontent.com/loonghao/dcc-mcp-ipc/main/logo.svg" alt="DCC-MCP-IPC Logo" width="200"/>
 
 [![PyPI version](https://badge.fury.io/py/dcc-mcp-ipc.svg)](https://badge.fury.io/py/dcc-mcp-ipc)
-[![Build Status](https://github.com/loonghao/dcc-mcp-ipc/workflows/Build%20and%20Release/badge.svg)](https://github.com/loonghao/dcc-mcp-ipc/actions)
+[![CI](https://github.com/loonghao/dcc-mcp-ipc/actions/workflows/ci.yml/badge.svg)](https://github.com/loonghao/dcc-mcp-ipc/actions/workflows/ci.yml)
 [![Python Version](https://img.shields.io/pypi/pyversions/dcc-mcp-ipc.svg)](https://pypi.org/project/dcc-mcp-ipc/)
 [![License](https://img.shields.io/github/license/loonghao/dcc-mcp-ipc.svg)](https://github.com/loonghao/dcc-mcp-ipc/blob/main/LICENSE)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Ruff](https://img.shields.io/badge/ruff-enabled-brightgreen)](https://github.com/astral-sh/ruff)
-[![Downloads](https://static.pepy.tech/badge/dcc-mcp-ipc)](https://pepy.tech/project/dcc-mcp-ipc)
 </div>
 
-[English](README.md) | [中文](README_zh.md)
+**Multi-protocol IPC adapter layer for DCC software integration with [Model Context Protocol (MCP)](https://modelcontextprotocol.io/).**
 
-Multi-protocol IPC adapter layer for DCC software integration with Model Context Protocol (MCP). Built on top of **dcc-mcp-core** (Rust/PyO3 backend), it provides a high-performance, type-safe framework for exposing DCC functionality as MCP tools.
+Built on top of **dcc-mcp-core** (Rust/PyO3 backend), it provides a high-performance, type-safe framework for exposing DCC functionality as MCP tools across multiple transport protocols.
+
+> **Documentation**: [docs site](https://loonghao.github.io/dcc-mcp-ipc/) | **v2.0.0** (Unreleased) — Breaking changes ahead, see [CHANGELOG.md](./CHANGELOG.md)
 
 ## Why DCC-MCP-IPC?
 
-- **Protocol-agnostic**: RPyC for embedded-Python DCCs (Maya/Houdini/Blender), HTTP for Unreal/Unity, and the new Rust-native IPC channel for maximum throughput.
-- **Zero-code Skills**: Drop a `SKILL.md` file into a directory and the `SkillManager` auto-registers it as an MCP tool — no Python boilerplate required.
-- **Rust performance**: Action dispatch, validation, and telemetry are handled by the Rust core via PyO3; Python layer focuses on DCC-specific glue code.
-- **Hot-reload**: `SkillWatcher` monitors skill directories and re-registers tools on file changes without restarting the DCC.
+| Feature | Description |
+|---------|-------------|
+| **Protocol-agnostic** | RPyC for embedded-Python DCCs (Maya/Houdini/Blender), HTTP for Unreal/Unity, WebSocket, and Rust-native IPC for maximum throughput. |
+| **Zero-code Skills** | Drop a `SKILL.md` file into a directory — `SkillManager` auto-registers it as an MCP tool. No Python boilerplate needed. |
+| **Rust-powered core** | Action dispatch, validation, and telemetry handled by dcc-mcp-core via PyO3; Python layer focuses on DCC-specific glue code. |
+| **Hot-reload skills** | `SkillWatcher` monitors skill directories and re-registers tools on file changes without restarting the DCC. |
+| **Service discovery** | ZeroConf (mDNS) + file-based fallback for automatic DCC server detection. |
+| **Connection pooling** | `ConnectionPool` with auto-discovery for efficient client-side connection reuse. |
 
 ## Features
 
-- Thread-safe RPyC server implementation for DCC applications
-- **Rust-native IPC transport** (`IpcListener` / `FramedChannel`) for zero-copy low-latency messaging
-- **Skills system** — zero-code MCP tool registration from `SKILL.md` frontmatter
-- **Hot-reload** of skills via `SkillWatcher` (debounced file watching)
-- Service discovery: ZeroConf (mDNS) + file-based fallback
-- Abstract base classes for creating DCC-specific adapters and services
-- Support for Maya, Houdini, 3ds Max, Nuke, Blender, Unreal Engine, Unity, etc.
-- Action system backed by `ActionRegistry` + `ActionDispatcher` (Rust)
-- Mock DCC services for testing without actual DCC applications
+- Thread-safe RPyC / HTTP / WebSocket / **Rust-native IPC** server implementations
+- **Skills system** — zero-code MCP tool registration from `SKILL.md` frontmatter with hot-reload
+- **Action system** backed by `ActionRegistry` + `ActionDispatcher` (Rust) — JSON-serialised parameter dispatch
+- **Transport factory** — pluggable transport layer (`rpyc`, `http`, `websocket`, `ipc`)
+- Service discovery: ZeroConf (mDNS) + file-based fallback via `ServiceDiscoveryFactory`
 - Async client (`asyncio`) for non-blocking operations
-- Comprehensive error handling and connection management
+- Abstract base classes for creating DCC-specific adapters (`DCCAdapter`) and services
+- Application adapter pattern for generic app integration
+- Scene & snapshot interfaces over RPyC and HTTP transports
+- Mock DCC services for testing without actual DCC applications
+- Comprehensive error handling with custom exception hierarchy
 
 ## Architecture
 
 ```mermaid
 graph TD
-    A[AI Assistant / MCP Client] --> B[MCP Server]
+    A[AI Assistant / MCP Client] --> B[MCP Server Layer]
     B --> C[ActionAdapter\nActionRegistry + ActionDispatcher]
     C --> D[RPyC Transport\nDCC Python env]
     C --> E[IPC Transport\nRust FramedChannel]
-    C --> F[HTTP Transport\nUnreal/Unity REST]
+    C --> F[HTTP Transport\nUnreal / Unity REST]
+    C --> G[WebSocket Transport]
     G[SkillManager\nSKILL.md auto-discovery] --> C
-    H[dcc-mcp-core\nRust/PyO3] --> C
+    H[dcc-mcp-core\nRust/PyO3 backend] --> C
     D --> I[DCC App\nMaya / Houdini / Blender]
     E --> I
     F --> J[DCC App\nUnreal / Unity]
+
+    style C fill:#e1f5fe
+    style H fill:#fff3e0
+    style G fill:#e8f5e9
 ```
 
-Key components:
+### Key Components
 
-- **`ActionAdapter`**: Wraps `ActionRegistry` + `ActionDispatcher` (Rust) — registers handlers and dispatches JSON-parameterised calls.
-- **`SkillManager`**: Scans directories for `SKILL.md` skills, registers them as `ActionAdapter` handlers, supports hot-reload.
-- **`IpcClientTransport` / `IpcServerTransport`**: Rust-native framed-channel IPC, registered as `"ipc"` protocol.
-- **`DCCServer`**: Manages the RPyC server lifecycle inside a DCC process.
-- **`BaseDCCClient` / `ConnectionPool`**: Client-side connection management with auto-discovery and pooling.
-- **`MockDCCService`**: Simulates DCC applications for testing and development.
+| Component | Module | Description |
+|-----------|--------|-------------|
+| `ActionAdapter` | `action_adapter.py` | Wraps Rust `ActionRegistry` + `ActionDispatcher`; registers handlers and dispatches JSON-parameterised calls |
+| `SkillManager` | `skills/scanner.py` | Scans directories for `SKILL.md` skills, registers them as action handlers, supports hot-reload |
+| `DCCServer` | `server/dcc.py` | Manages the RPyC/IPC server lifecycle inside a DCC process |
+| `BaseDCCClient` | `client/base.py` | Core client connection/call logic with auto-discovery |
+| `ConnectionPool` | `client/pool.py` | Connection pooling for efficient resource management |
+| `IpcClientTransport` / `IpcServerTransport` | `transport/ipc_transport.py` | Rust-native framed-channel IPC, registered as `"ipc"` protocol |
+| `ServiceDiscoveryFactory` | `discovery/factory.py` | Strategy-pattern selector for ZeroConf or file-based discovery |
+| `MockDCCService` | `testing/mock_services.py` | Simulates DCC applications for testing |
 
 ## Installation
 
 ```bash
 pip install dcc-mcp-ipc
+```
+
+With optional ZeroConf support:
+
+```bash
+pip install "dcc-mcp-ipc[zeroconf]"
 ```
 
 Or with Poetry:
@@ -74,82 +94,70 @@ Or with Poetry:
 poetry add dcc-mcp-ipc
 ```
 
-## Usage
+### Requirements
+
+- Python >= 3.8 (< 4.0)
+- [dcc-mcp-core](https://pypi.org/project/dcc-mcp-core/) >= 0.12.0 (< 1.0.0)
+- [rpyc](https://rpyc.readthedocs.io/) >= 6.0.0 (< 7.0.0)
+- Optional: [zeroconf](https://github.com/jstasiak/python-zeroconf) >= 0.38.0 for mDNS discovery
+
+## Quick Start
 
 ### Server-side (within DCC application)
 
-```python
-# Create and start a DCC server in Maya
+<augment_code_snippet path="README.md" mode="EXCERPT">
+````python
 from dcc_mcp_ipc.server import create_dcc_server, DCCRPyCService
 
-# Create a custom service class
+
 class MayaService(DCCRPyCService):
     def get_scene_info(self):
-        # Implement Maya-specific scene info retrieval
         return {"scene": "Maya scene info"}
 
     def exposed_execute_cmd(self, cmd_name, *args, **kwargs):
-        # Implement Maya command execution
         pass
 
-# Create and start the server
+
 server = create_dcc_server(
     dcc_name="maya",
     service_class=MayaService,
-    port=18812  # Optional, will use random port if not specified
+    port=18812,
 )
-
-# Start the server (threaded=True to avoid blocking Maya's main thread)
 server.start(threaded=True)
-```
+````
+</augment_code_snippet>
 
-### Using Service Factories
+### Client-side
 
-```python
-from dcc_mcp_ipc.server import create_service_factory, create_shared_service_instance, create_raw_threaded_server
+<augment_code_snippet path="README.md" mode="EXCERPT">
+````python
+from dcc_mcp_ipc.client import BaseDCCClient
 
-# Create a shared state manager
-class SceneManager:
-    def __init__(self):
-        self.scenes = {}
 
-    def add_scene(self, name, data):
-        self.scenes[name] = data
+client = BaseDCCClient("maya", host="localhost", port=18812)
+client.connect()
+result = client.call("get_scene_info")
+client.disconnect()
+````
+</augment_code_snippet>
 
-# Method 1: Create a service factory (new instance per connection)
-scene_manager = SceneManager()
-service_factory = create_service_factory(MayaService, scene_manager)
+## Usage Guide
 
-# Method 2: Create a shared service instance (single instance for all connections)
-shared_service = create_shared_service_instance(MayaService, scene_manager)
+### Action System (v2.0.0+)
 
-# Create a server with the service factory
-server = create_raw_threaded_server(service_factory, port=18812)
-server.start()
-```
+The Action system is built on the Rust-backed `ActionRegistry` + `ActionDispatcher`. All parameters are JSON-serialised:
 
-### Parameter Handling
-
-```python
-from dcc_mcp_ipc.utils.rpyc_utils import deliver_parameters, execute_remote_command
-
-# Process RPyC NetRef parameters
-params = {"radius": 5.0, "create": True, "name": "mySphere"}
-processed = deliver_parameters(params)
-```
-
-### Using the Action System (v2.0.0+)
-
-```python
+<augment_code_snippet path="README.md" mode="EXCERPT">
+````python
 from dcc_mcp_ipc.action_adapter import ActionAdapter, get_action_adapter
 
-# Get or create an adapter (cached by name)
+
 adapter = get_action_adapter("maya")
 
-# Register a handler function
+
 def create_sphere(radius: float = 1.0, name: str = "sphere1") -> dict:
-    # DCC-specific implementation
-    return {"success": True, "message": f"Created {name}", "context": {"name": name, "radius": radius}}
+    return {"success": True, "message": f"Created {name}", "context": {"name": name}}
+
 
 adapter.register_action(
     "create_sphere",
@@ -159,51 +167,106 @@ adapter.register_action(
     tags=["primitive", "mesh"],
 )
 
-# Dispatch the action — params are JSON-serialised automatically
+
 result = adapter.call_action("create_sphere", radius=2.0, name="mySphere")
 print(result.success)   # True
-print(result.message)   # "Created mySphere"
-
-# Serialise to plain dict
-data = result.to_dict()
-```
+print(result.to_dict()) # {"success": True, ...}
+````
+</augment_code_snippet>
 
 ### Zero-code Skills via SkillManager
 
-Drop a `SKILL.md` file anywhere:
+Drop a `SKILL.md` file into a directory structure:
 
 ```
 my_skills/
   create_light/
-    SKILL.md      ← frontmatter with name, description, tools, scripts
-    run.py        ← executed when the tool is called
+    SKILL.md      # frontmatter: name, description, tools, scripts
+    run.py        # executed when the tool is called
 ```
 
-```python
+<augment_code_snippet path="README.md" mode="EXCERPT">
+````python
 from dcc_mcp_ipc.skills import SkillManager
 from dcc_mcp_ipc.action_adapter import get_action_adapter
+
 
 adapter = get_action_adapter("maya")
 mgr = SkillManager(adapter=adapter, dcc_name="maya")
 
-# Scan and register all skills from a directory
 mgr.load_paths(["/pipeline/skills"])
-
-# Enable hot-reload on file changes
 mgr.start_watching()
 
 # Now "create_light" is callable as an MCP tool
 result = adapter.call_action("create_light", intensity=100.0)
-```
+````
+</augment_code_snippet>
+
+### Connection Pool
+
+<augment_code_snippet path="README.md" mode="EXCERPT">
+````python
+from dcc_mcp_ipc.client import ConnectionPool
+
+
+pool = ConnectionPool()
+
+with pool.get_client("maya", host="localhost") as client:
+    result = client.call("execute_cmd", "sphere", radius=5)
+    print(result)
+````
+</augment_code_snippet>
+
+### Service Factories
+
+Three factory patterns are available for different lifecycle needs:
+
+<augment_code_snippet path="README.md" mode="EXCERPT">
+````python
+from dcc_mcp_ipc.server import (
+    create_service_factory,
+    create_shared_service_instance,
+    create_raw_threaded_server,
+)
+
+
+class SceneManager:
+    def __init__(self):
+        self.scenes = {}
+
+    def add_scene(self, name, data):
+        self.scenes[name] = data
+
+
+scene_manager = SceneManager()
+
+# Per-connection instance
+service_factory = create_service_factory(MayaService, scene_manager)
+
+# Shared singleton instance
+shared_service = create_shared_service_instance(MayaService, scene_manager)
+
+# Raw threaded server
+server = create_raw_threaded_server(service_factory, port=18812)
+server.start()
+````
+</augment_code_snippet>
 
 ### Rust-native IPC Transport
 
-```python
+Zero-copy low-latency messaging via the Rust core:
+
+<augment_code_snippet path="README.md" mode="EXCERPT">
+````python
 import os
 from dcc_mcp_core import TransportAddress
-from dcc_mcp_ipc.transport.ipc_transport import IpcClientTransport, IpcTransportConfig
+from dcc_mcp_ipc.transport.ipc_transport import (
+    IpcClientTransport,
+    IpcServerTransport,
+    IpcTransportConfig,
+)
 
-# Client side (MCP server / test)
+# Client side
 config = IpcTransportConfig(host="localhost", port=19000)
 transport = IpcClientTransport(config)
 transport.connect()
@@ -211,72 +274,23 @@ result = transport.execute("get_scene_info")
 transport.disconnect()
 
 # Server side (inside DCC plugin)
-from dcc_mcp_ipc.transport.ipc_transport import IpcServerTransport
-
 def handle_channel(channel):
     msg = channel.recv()
-    # ... process and respond ...
+    # process and respond ...
 
 addr = TransportAddress.default_local("maya", os.getpid())
 server = IpcServerTransport(addr, handler=handle_channel)
 bound_addr = server.start()
-print(f"IPC server at: {bound_addr}")
-```
+````
+</augment_code_snippet>
 
-### Using Mock DCC Services for Testing
+### Creating a Custom DCC Adapter
 
-```python
-import threading
-import rpyc
-from rpyc.utils.server import ThreadedServer
-from dcc_mcp_ipc.client import BaseDCCClient
-from dcc_mcp_ipc.utils.discovery import register_service
-
-# Create a mock DCC service
-class MockDCCService(rpyc.Service):
-    def exposed_get_dcc_info(self, conn=None):
-        return {
-            "name": "mock_dcc",
-            "version": "1.0.0",
-            "platform": "windows",
-        }
-    
-    def exposed_execute_python(self, code, conn=None):
-        # Safe execution of Python code in a controlled environment
-        local_vars = {}
-        exec(code, {}, local_vars)
-        if "_result" in local_vars:
-            return local_vars["_result"]
-        return None
-
-# Start the mock service
-server = ThreadedServer(
-    MockDCCService,
-    port=18812,
-    protocol_config={"allow_public_attrs": True}
-)
-
-# Register the service for discovery
-register_service("mock_dcc", "localhost", 18812)
-
-# Start in a separate thread
-thread = threading.Thread(target=server.start, daemon=True)
-thread.start()
-
-# Connect a client to the mock service
-client = BaseDCCClient("mock_dcc", host="localhost", port=18812)
-client.connect()
-
-# Use the client as if it were connected to a real DCC
-dcc_info = client.get_dcc_info()
-print(dcc_info)  # {"name": "mock_dcc", "version": "1.0.0", "platform": "windows"}
-```
-
-### Creating a DCC Adapter
-
-```python
+<augment_code_snippet path="README.md" mode="EXCERPT">
+````python
 from dcc_mcp_ipc.adapter import DCCAdapter
 from dcc_mcp_ipc.client import BaseDCCClient
+
 
 class MayaAdapter(DCCAdapter):
     def _initialize_client(self) -> None:
@@ -291,34 +305,91 @@ class MayaAdapter(DCCAdapter):
         self.ensure_connected()
         assert self.client is not None
         return self.client.execute_dcc_command(f"sphere -r {radius};")
-```
+````
+</augment_code_snippet>
+
+### Async Client
+
+<augment_code_snippet path="README.md" mode="EXCERPT">
+````python
+import asyncio
+from dcc_mcp_ipc.client.async_dcc import AsyncDCCClient
+
+
+async def main():
+    client = AsyncDCCClient("maya", host="localhost", port=18812)
+    await client.connect()
+    result = await client.call("get_scene_info")
+    await client.disconnect()
+
+
+asyncio.run(main())
+````
+</augment_code_snippet>
+
+### Testing with Mock Services
+
+<augment_code_snippet path="README.md" mode="EXCERPT">
+````python
+import threading
+from dcc_mcp_ipc.testing.mock_services import MockDCCService
+from dcc_mcp_ipc.client import BaseDCCClient
+
+
+server = MockDCCService.start(port=18812)
+
+client = BaseDCCClient("mock_dcc", host="localhost", port=18812)
+client.connect()
+info = client.get_dcc_info()
+print(info)  # {"name": "mock_dcc", ...}
+client.disconnect()
+server.stop()
+````
+</augment_code_snippet>
 
 ## Development
 
 ### Setup
 
 ```bash
-# Clone the repository
 git clone https://github.com/loonghao/dcc-mcp-ipc.git
 cd dcc-mcp-ipc
-
-# Install dependencies with Poetry
 poetry install
 ```
 
-### Testing
+### Running Tasks
 
 ```bash
-# Run tests with nox
-nox -s pytest
+nox -s pytest          # Run tests
+nox -s lint            # Lint (mypy + ruff + isort)
+nox -s lint-fix        # Auto-fix lint issues
+nox -s build           # Build distribution packages
+```
 
-# Run linting
-nox -s lint
+### Project Structure
 
-# Fix linting issues
-nox -s lint-fix
+```
+dcc-mcp-ipc/
+├── src/dcc_mcp_ipc/
+│   ├── __init__.py              # Lazy-import public API surface
+│   ├── action_adapter.py         # Action system (Rust-backed)
+│   ├── adapter/                  # DCC & application adapters
+│   ├── client/                   # Synchronous & async clients + pool
+│   ├── server/                   # RPyC server + factories + lifecycle
+│   ├── transport/                # RPyC / HTTP / WS / IPC transports
+│   ├── discovery/                # ZeroConf + file-based service discovery
+│   ├── skills/                   # SkillManager zero-code system
+│   ├── scene/                    # Scene operations interface
+│   ├── snapshot/                 # Snapshot interface
+│   ├── application/              # Generic application adapter/service/client
+│   ├── testing/                  # Mock services for testing
+│   └── utils/                    # Errors, DI, decorators, RPyC helpers
+├── tests/                        # 68 test files mirroring source layout
+├── examples/                     # Usage examples
+├── docs/                         # VitePress documentation site
+└── nox_actions/                  # Nox task definitions
 ```
 
 ## License
 
-MIT
+[MIT](./LICENSE)

--- a/README_zh.md
+++ b/README_zh.md
@@ -4,69 +4,88 @@
     <img src="https://raw.githubusercontent.com/loonghao/dcc-mcp-ipc/main/logo.svg" alt="DCC-MCP-IPC Logo" width="200"/>
 
 [![PyPI version](https://badge.fury.io/py/dcc-mcp-ipc.svg)](https://badge.fury.io/py/dcc-mcp-ipc)
-[![Build Status](https://github.com/loonghao/dcc-mcp-ipc/workflows/Build%20and%20Release/badge.svg)](https://github.com/loonghao/dcc-mcp-ipc/actions)
+[![CI](https://github.com/loonghao/dcc-mcp-ipc/actions/workflows/ci.yml/badge.svg)](https://github.com/loonghao/dcc-mcp-ipc/actions/workflows/ci.yml)
 [![Python Version](https://img.shields.io/pypi/pyversions/dcc-mcp-ipc.svg)](https://pypi.org/project/dcc-mcp-ipc/)
 [![License](https://img.shields.io/github/license/loonghao/dcc-mcp-ipc.svg)](https://github.com/loonghao/dcc-mcp-ipc/blob/main/LICENSE)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Ruff](https://img.shields.io/badge/ruff-enabled-brightgreen)](https://github.com/astral-sh/ruff)
-[![Downloads](https://static.pepy.tech/badge/dcc-mcp-ipc)](https://pepy.tech/project/dcc-mcp-ipc)
 </div>
 
-[English](README.md) | [中文](README_zh.md)
+**DCC 软件与 [模型上下文协议 (MCP)](https://modelcontextprotocol.io/) 集成的多协议 IPC 适配层。**
 
-DCC 软件与模型上下文协议 (MCP) 集成的多协议 IPC 适配层。基于 **dcc-mcp-core**（Rust/PyO3 后端）构建，为将 DCC 功能作为 MCP 工具暴露提供高性能、类型安全的框架。
+基于 **dcc-mcp-core**（Rust/PyO3 后端）构建，为将 DCC 功能作为 MCP 工具暴露提供高性能、类型安全的框架，支持多种传输协议。
+
+> **文档**: [文档站点](https://loonghao.github.io/dcc-mcp-ipc/) | **v2.0.0**（未发布）— 包含破坏性变更，请参阅 [CHANGELOG.md](./CHANGELOG.md)
 
 ## 为什么选择 DCC-MCP-IPC？
 
-- **协议无关**：RPyC 用于内嵌 Python 的 DCC（Maya/Houdini/Blender），HTTP 用于 Unreal/Unity，Rust 原生 IPC 通道提供最高吞吐量。
-- **零代码 Skills**：在目录中放置一个 `SKILL.md` 文件，`SkillManager` 就会自动将其注册为 MCP 工具——无需 Python 样板代码。
-- **Rust 性能**：Action 派发、验证和遥测由 Rust 核心通过 PyO3 处理；Python 层专注于 DCC 特定的胶水代码。
-- **热重载**：`SkillWatcher` 监控 skill 目录，文件变更时无需重启 DCC 即可重新注册工具。
+| 特性 | 说明 |
+|------|------|
+| **协议无关** | RPyC 用于内嵌 Python 的 DCC（Maya/Houdini/Blender），HTTP 用于 Unreal/Unity，WebSocket，以及 Rust 原生 IPC 通道提供最高吞吐量。 |
+| **零代码 Skills** | 在目录中放置一个 `SKILL.md` 文件，`SkillManager` 就会自动将其注册为 MCP 工具，无需 Python 样板代码。 |
+| **Rust 性能核心** | Action 派发、验证和遥测由 dcc-mcp-core 通过 PyO3 处理；Python 层专注于 DCC 特定的胶水代码。 |
+| **热重载 Skills** | `SkillWatcher` 监控 skill 目录，文件变更时无需重启 DCC 即可重新注册工具。 |
+| **服务发现** | ZeroConf（mDNS）+ 文件备份策略，自动检测 DCC 服务器。 |
+| **连接池** | `ConnectionPool` 支持自动发现，实现高效的客户端连接复用。 |
 
-## 特性
+## 功能特性
 
-- 为 DCC 应用程序提供线程安全的 RPyC 服务器实现
-- **Rust 原生 IPC 传输**（`IpcListener` / `FramedChannel`）提供零拷贝低延迟消息传递
-- **Skills 系统** — 通过 `SKILL.md` frontmatter 进行零代码 MCP 工具注册
-- 通过 `SkillWatcher` 对 skills 进行**热重载**（防抖文件监控）
-- 服务发现：ZeroConf（mDNS）+ 文件备份策略
-- 提供抽象基类，用于创建特定 DCC 的适配器和服务
-- 支持 Maya、Houdini、3ds Max、Nuke、Blender、Unreal Engine、Unity 等
-- 由 `ActionRegistry` + `ActionDispatcher`（Rust）支持的 Action 系统
-- 模拟 DCC 服务，用于无需实际 DCC 应用程序的测试
+- 线程安全的 RPyC / HTTP / WebSocket / **Rust 原生 IPC** 服务器实现
+- **Skills 系统** — 通过 `SKILL.md` frontmatter 进行零代码 MCP 工具注册，支持热重载
+- **Action 系统** — 基于 `ActionRegistry` + `ActionDispatcher`（Rust），使用 JSON 序列化参数派发
+- **传输工厂** — 可插拔传输层（`rpyc`、`http`、`websocket`、`ipc`）
+- 服务发现：ZeroConf（mDNS）+ 文件备份策略，通过 `ServiceDiscoveryFactory` 统一管理
 - 异步客户端（asyncio）支持非阻塞操作
-- 全面的错误处理和连接管理
+- 提供抽象基类，用于创建特定 DCC 的适配器（`DCCAdapter`）和服务
+- 应用适配器模式，支持通用应用集成
+- 通过 RPyC 和 HTTP 传输的场景与快照接口
+- 模拟 DCC 服务，用于无需实际 DCC 应用程序的测试
+- 包含自定义异常体系的全面错误处理
 
 ## 架构
 
 ```mermaid
 graph TD
-    A[AI 助手 / MCP 客户端] --> B[MCP 服务器]
+    A[AI 助手 / MCP 客户端] --> B[MCP 服务器层]
     B --> C[ActionAdapter\nActionRegistry + ActionDispatcher]
     C --> D[RPyC 传输\nDCC Python 环境]
     C --> E[IPC 传输\nRust FramedChannel]
-    C --> F[HTTP 传输\nUnreal/Unity REST]
+    C --> F[HTTP 传输\nUnreal / Unity REST]
+    C --> G[WebSocket 传输]
     G[SkillManager\nSKILL.md 自动发现] --> C
-    H[dcc-mcp-core\nRust/PyO3] --> C
+    H[dcc-mcp-core\nRust/PyO3 后端] --> C
     D --> I[DCC 应用\nMaya / Houdini / Blender]
     E --> I
     F --> J[DCC 应用\nUnreal / Unity]
+
+    style C fill:#e1f5fe
+    style H fill:#fff3e0
+    style G fill:#e8f5e9
 ```
 
-核心组件：
+### 核心组件
 
-- **`ActionAdapter`**：包装 `ActionRegistry` + `ActionDispatcher`（Rust）— 注册处理程序并派发 JSON 参数化调用。
-- **`SkillManager`**：扫描 `SKILL.md` skills 目录，将其注册为 `ActionAdapter` 处理程序，支持热重载。
-- **`IpcClientTransport` / `IpcServerTransport`**：Rust 原生帧通道 IPC，注册为 `"ipc"` 协议。
-- **`DCCServer`**：管理 DCC 进程内的 RPyC 服务器生命周期。
-- **`BaseDCCClient` / `ConnectionPool`**：客户端连接管理，支持自动发现和连接池。
-- **`MockDCCService`**：模拟 DCC 应用程序用于测试和开发。
-
+| 组件 | 模块 | 说明 |
+|------|------|------|
+| `ActionAdapter` | `action_adapter.py` | 包装 Rust `ActionRegistry` + `ActionDispatcher`；注册处理程序并派发 JSON 参数化调用 |
+| `SkillManager` | `skills/scanner.py` | 扫描 `SKILL.md` skills 目录，注册为 action 处理程序，支持热重载 |
+| `DCCServer` | `server/dcc.py` | 管理 DCC 进程内的 RPyC/IPC 服务器生命周期 |
+| `BaseDCCClient` | `client/base.py` | 核心客户端连接/调用逻辑，支持自动发现 |
+| `ConnectionPool` | `client/pool.py` | 连接池，高效管理客户端连接资源 |
+| `IpcClientTransport` / `IpcServerTransport` | `transport/ipc_transport.py` | Rust 原生帧通道 IPC，注册为 `"ipc"` 协议 |
+| `ServiceDiscoveryFactory` | `discovery/factory.py` | ZeroConf 或文件服务发现的策略模式选择器 |
+| `MockDCCService` | `testing/mock_services.py` | 模拟 DCC 应用程序用于测试 |
 
 ## 安装
 
 ```bash
 pip install dcc-mcp-ipc
+```
+
+安装可选的 ZeroConf 支持：
+
+```bash
+pip install "dcc-mcp-ipc[zeroconf]"
 ```
 
 或者使用 Poetry：
@@ -75,32 +94,34 @@ pip install dcc-mcp-ipc
 poetry add dcc-mcp-ipc
 ```
 
-## 使用方法
+### 依赖要求
+
+- Python >= 3.8 (< 4.0)
+- [dcc-mcp-core](https://pypi.org/project/dcc-mcp-core/) >= 0.12.0 (< 1.0.0)
+- [rpyc](https://rpyc.readthedocs.io/) >= 6.0.0 (< 7.0.0)
+- 可选：[zeroconf](https://github.com/jstasiak/python-zeroconf) >= 0.38.0（mDNS 发现）
+
+## 快速上手
 
 ### 服务器端（在 DCC 应用程序内）
 
 ```python
-# 在 Maya 中创建并启动 DCC 服务器
 from dcc_mcp_ipc.server import create_dcc_server, DCCRPyCService
 
-# 创建自定义服务类
+
 class MayaService(DCCRPyCService):
     def get_scene_info(self):
-        # 实现 Maya 特定的场景信息获取
         return {"scene": "Maya 场景信息"}
 
     def exposed_execute_cmd(self, cmd_name, *args, **kwargs):
-        # 实现 Maya 命令执行
         pass
 
-# 创建并启动服务器
+
 server = create_dcc_server(
     dcc_name="maya",
     service_class=MayaService,
-    port=18812  # 可选，如果不指定将使用随机端口
+    port=18812,
 )
-
-# 启动服务器（threaded=True 避免阻塞 Maya 的主线程）
 server.start(threaded=True)
 ```
 
@@ -109,50 +130,152 @@ server.start(threaded=True)
 ```python
 from dcc_mcp_ipc.client import BaseDCCClient
 
-# 连接到 DCC 服务器
-client = BaseDCCClient(
-    dcc_name="maya",
-    host="localhost",
-    port=18812  # 可选，如果不指定将自动发现
-)
 
-# 连接到服务器
+client = BaseDCCClient("maya", host="localhost", port=18812)
 client.connect()
-
-# 调用远程方法
-result = client.call("execute_cmd", "sphere", radius=5)
-print(result)
-
-# 获取场景信息
-scene_info = client.call("get_scene_info")
-print(scene_info)
-
-# 完成后断开连接
+result = client.call("get_scene_info")
 client.disconnect()
 ```
 
-### 使用连接池
+## 使用指南
+
+### Action 系统（v2.0.0+）
+
+Action 系统基于 Rust 后端的 `ActionRegistry` + `ActionDispatcher` 构建，所有参数均使用 JSON 序列化：
+
+```python
+from dcc_mcp_ipc.action_adapter import ActionAdapter, get_action_adapter
+
+
+adapter = get_action_adapter("maya")
+
+
+def create_sphere(radius: float = 1.0, name: str = "sphere1") -> dict:
+    return {"success": True, "message": f"Created {name}", "context": {"name": name}}
+
+
+adapter.register_action(
+    "create_sphere",
+    create_sphere,
+    description="创建一个球体基元",
+    category="modeling",
+    tags=["primitive", "mesh"],
+)
+
+
+result = adapter.call_action("create_sphere", radius=2.0, name="mySphere")
+print(result.success)   # True
+print(result.to_dict()) # {"success": True, ...}
+```
+
+### 通过 SkillManager 实现零代码 Skills
+
+在目录结构中放置 `SKILL.md` 文件：
+
+```
+my_skills/
+  create_light/
+    SKILL.md      # frontmatter: name, description, tools, scripts
+    run.py        # 工具被调用时执行此文件
+```
+
+```python
+from dcc_mcp_ipc.skills import SkillManager
+from dcc_mcp_ipc.action_adapter import get_action_adapter
+
+
+adapter = get_action_adapter("maya")
+mgr = SkillManager(adapter=adapter, dcc_name="maya")
+
+mgr.load_paths(["/pipeline/skills"])
+mgr.start_watching()
+
+# 现在 "create_light" 可作为 MCP 工具调用
+result = adapter.call_action("create_light", intensity=100.0)
+```
+
+### 连接池
 
 ```python
 from dcc_mcp_ipc.client import ConnectionPool
 
-# 创建连接池
+
 pool = ConnectionPool()
 
-# 从连接池获取客户端（如果需要，会创建新连接）
 with pool.get_client("maya", host="localhost") as client:
-    # 在客户端上调用方法
     result = client.call("execute_cmd", "sphere", radius=5)
     print(result)
-
-# 连接自动返回到连接池
 ```
 
-### 创建 DCC 适配器
+### 服务工厂
+
+三种工厂模式满足不同生命周期需求：
+
+```python
+from dcc_mcp_ipc.server import (
+    create_service_factory,
+    create_shared_service_instance,
+    create_raw_threaded_server,
+)
+
+
+class SceneManager:
+    def __init__(self):
+        self.scenes = {}
+
+    def add_scene(self, name, data):
+        self.scenes[name] = data
+
+
+scene_manager = SceneManager()
+
+# 每连接一个新实例
+service_factory = create_service_factory(MayaService, scene_manager)
+
+# 所有连接共享单一实例
+shared_service = create_shared_service_instance(MayaService, scene_manager)
+
+# 原始线程服务器
+server = create_raw_threaded_server(service_factory, port=18812)
+server.start()
+```
+
+### Rust 原生 IPC 传输
+
+通过 Rust 核心实现零拷贝低延迟消息传递：
+
+```python
+import os
+from dcc_mcp_core import TransportAddress
+from dcc_mcp_ipc.transport.ipc_transport import (
+    IpcClientTransport,
+    IpcServerTransport,
+    IpcTransportConfig,
+)
+
+# 客户端
+config = IpcTransportConfig(host="localhost", port=19000)
+transport = IpcClientTransport(config)
+transport.connect()
+result = transport.execute("get_scene_info")
+transport.disconnect()
+
+# 服务器端（DCC 插件内）
+def handle_channel(channel):
+    msg = channel.recv()
+    # 处理并响应...
+
+addr = TransportAddress.default_local("maya", os.getpid())
+server = IpcServerTransport(addr, handler=handle_channel)
+bound_addr = server.start()
+```
+
+### 创建自定义 DCC 适配器
 
 ```python
 from dcc_mcp_ipc.adapter import DCCAdapter
 from dcc_mcp_ipc.client import BaseDCCClient
+
 
 class MayaAdapter(DCCAdapter):
     def _initialize_client(self) -> None:
@@ -169,33 +292,83 @@ class MayaAdapter(DCCAdapter):
         return self.client.execute_dcc_command(f"sphere -r {radius};")
 ```
 
+### 异步客户端
+
+```python
+import asyncio
+from dcc_mcp_ipc.client.async_dcc import AsyncDCCClient
+
+
+async def main():
+    client = AsyncDCCClient("maya", host="localhost", port=18812)
+    await client.connect()
+    result = await client.call("get_scene_info")
+    await client.disconnect()
+
+
+asyncio.run(main())
+```
+
+### 使用模拟服务进行测试
+
+```python
+from dcc_mcp_ipc.testing.mock_services import MockDCCService
+from dcc_mcp_ipc.client import BaseDCCClient
+
+
+server = MockDCCService.start(port=18812)
+
+client = BaseDCCClient("mock_dcc", host="localhost", port=18812)
+client.connect()
+info = client.get_dcc_info()
+print(info)  # {"name": "mock_dcc", ...}
+client.disconnect()
+server.stop()
+```
+
 ## 开发
 
 ### 环境设置
 
 ```bash
-# 克隆仓库
 git clone https://github.com/loonghao/dcc-mcp-ipc.git
 cd dcc-mcp-ipc
-
-# 使用 Poetry 安装依赖
 poetry install
 ```
 
-### 测试
+### 常用命令
 
 ```bash
-# 使用 nox 运行测试
-nox -s pytest
+nox -s pytest          # 运行测试
+nox -s lint            # 代码检查（mypy + ruff + isort）
+nox -s lint-fix        # 自动修复代码规范问题
+nox -s build           # 构建发布包
+```
 
-# 运行代码检查
-nox -s lint
+### 项目结构
 
-# 修复代码检查问题
-nox -s lint-fix
+```
+dcc-mcp-ipc/
+├── src/dcc_mcp_ipc/
+│   ├── __init__.py              # 懒加载公共 API 入口
+│   ├── action_adapter.py         # Action 系统（Rust 后端）
+│   ├── adapter/                  # DCC 和应用适配器
+│   ├── client/                   # 同步/异步客户端 + 连接池
+│   ├── server/                   # RPyC 服务器 + 工厂 + 生命周期
+│   ├── transport/                # RPyC / HTTP / WS / IPC 传输层
+│   ├── discovery/                # ZeroConf + 文件服务发现
+│   ├── skills/                   # SkillManager 零代码系统
+│   ├── scene/                    # 场景操作接口
+│   ├── snapshot/                 # 快照接口
+│   ├── application/              # 通用应用适配器/服务/客户端
+│   ├── testing/                  # 测试用模拟服务
+│   └── utils/                    # 错误、DI、装饰器、RPyC 工具
+├── tests/                        # 68 个测试文件，与源码结构对应
+├── examples/                     # 使用示例
+├── docs/                         # VitePress 文档站点
+└── nox_actions/                  # Nox 任务定义
 ```
 
 ## 许可证
 
-MIT
-
+[MIT](./LICENSE)

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,0 +1,121 @@
+import { defineConfig } from 'vitepress'
+
+export default defineConfig({
+  title: 'DCC-MCP-IPC',
+  description: 'Multi-protocol IPC adapter layer for DCC software integration with Model Context Protocol',
+  base: '/dcc-mcp-ipc/',
+  lang: 'en-US',
+
+  head: [
+    ['link', { rel: 'icon', type: 'image/svg+xml', href: '/dcc-mcp-ipc/logo.svg' }],
+    ['meta', { name: 'theme-color', content: '#646cff' }],
+    ['meta', { property: 'og:type', content: 'website' }],
+    ['meta', { property: 'og:title', content: 'DCC-MCP-IPC' }],
+    ['meta', { property: 'og:description', content: 'Multi-protocol IPC adapter layer for DCC software' }],
+  ],
+
+  themeConfig: {
+    logo: {
+      src: '/logo.svg',
+      alt: 'DCC-MCP-IPC',
+    },
+
+    nav: [
+      { text: 'Guide', link: '/guide/introduction' },
+      { text: 'API Reference', link: '/api/overview' },
+      { text: 'Examples', link: '/examples/quickstart' },
+      {
+        text: 'v2.0.0',
+        items: [
+          { text: 'Changelog', link: 'https://github.com/loonghao/dcc-mcp-ipc/blob/main/CHANGELOG.md' },
+          { text: 'Contributing', link: 'https://github.com/loonghao/dcc-mcp-ipc/blob/main/CONTRIBUTING.md' },
+        ],
+      },
+    ],
+
+    sidebar: {
+      '/guide/': [
+        {
+          text: 'Getting Started',
+          items: [
+            { text: 'Introduction', link: '/guide/introduction' },
+            { text: 'Installation', link: '/guide/installation' },
+            { text: 'Quick Start', link: '/guide/quickstart' },
+          ],
+        },
+        {
+          text: 'Core Concepts',
+          items: [
+            { text: 'Architecture', link: '/guide/architecture' },
+            { text: 'Action System', link: '/guide/action-system' },
+            { text: 'Skills System', link: '/guide/skills' },
+            { text: 'Transport Layer', link: '/guide/transports' },
+            { text: 'Service Discovery', link: '/guide/discovery' },
+          ],
+        },
+        {
+          text: 'Advanced',
+          items: [
+            { text: 'Connection Pool', link: '/guide/connection-pool' },
+            { text: 'Async Client', link: '/guide/async-client' },
+            { text: 'Custom Adapters', link: '/guide/custom-adapters' },
+            { text: 'Testing', link: '/guide/testing' },
+          ],
+        },
+      ],
+      '/api/': [
+        {
+          text: 'API Reference',
+          items: [
+            { text: 'Overview', link: '/api/overview' },
+            { text: 'ActionAdapter', link: '/api/action-adapter' },
+            { text: 'SkillManager', link: '/api/skill-manager' },
+            { text: 'DCCServer', link: '/api/server' },
+            { text: 'BaseDCCClient', link: '/api/client' },
+            { text: 'ConnectionPool', link: '/api/connection-pool' },
+            { text: 'Transports', link: '/api/transports' },
+            { text: 'Discovery', link: '/api/discovery' },
+          ],
+        },
+      ],
+      '/examples/': [
+        {
+          text: 'Examples',
+          items: [
+            { text: 'Quick Start', link: '/examples/quickstart' },
+            { text: 'Maya Integration', link: '/examples/maya' },
+            { text: 'Houdini Integration', link: '/examples/houdini' },
+            { text: 'Blender Integration', link: '/examples/blender' },
+            { text: 'Service Factories', link: '/examples/service-factories' },
+            { text: 'Skills Example', link: '/examples/skills' },
+          ],
+        },
+      ],
+    },
+
+    socialLinks: [
+      { icon: 'github', link: 'https://github.com/loonghao/dcc-mcp-ipc' },
+    ],
+
+    footer: {
+      message: 'Released under the MIT License.',
+      copyright: 'Copyright © 2024-present Hal Long',
+    },
+
+    editLink: {
+      pattern: 'https://github.com/loonghao/dcc-mcp-ipc/edit/main/docs/:path',
+      text: 'Edit this page on GitHub',
+    },
+
+    search: {
+      provider: 'local',
+    },
+  },
+
+  markdown: {
+    theme: {
+      light: 'github-light',
+      dark: 'github-dark',
+    },
+  },
+})

--- a/docs/api/action-adapter.md
+++ b/docs/api/action-adapter.md
@@ -1,0 +1,88 @@
+# ActionAdapter
+
+`ActionAdapter` is the central registry and dispatcher for MCP-callable actions. It wraps the Rust/PyO3 `ActionRegistry` and `ActionDispatcher` from `dcc-mcp-core`.
+
+## Import
+
+```python
+from dcc_mcp_ipc.action_adapter import ActionAdapter, get_action_adapter
+```
+
+## Factory
+
+```python
+adapter = get_action_adapter("maya")  # Returns cached instance by name
+```
+
+`get_action_adapter(name: str) -> ActionAdapter`
+
+Returns the same `ActionAdapter` instance for the same `name` (singleton per DCC name). Creates a new instance on first call.
+
+## Methods
+
+### `register_action`
+
+```python
+adapter.register_action(
+    name: str,
+    handler: Callable,
+    description: str = "",
+    category: str = "",
+    tags: list[str] | None = None,
+) -> None
+```
+
+Register a callable as a named action.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | `str` | Unique action identifier |
+| `handler` | `Callable` | Function to invoke when dispatched |
+| `description` | `str` | Human-readable description (surfaced in MCP tool schema) |
+| `category` | `str` | Logical grouping |
+| `tags` | `list[str]` | Searchable tags |
+
+### `call_action`
+
+```python
+result = adapter.call_action(name: str, **kwargs) -> ActionResultModel
+```
+
+Dispatch a registered action with keyword arguments. All arguments are JSON-serialised.
+
+### `list_actions`
+
+```python
+actions = adapter.list_actions() -> list[ActionInfo]
+```
+
+Returns metadata for all registered actions.
+
+### `unregister_action`
+
+```python
+adapter.unregister_action(name: str) -> None
+```
+
+Remove a registered action.
+
+## ActionResultModel
+
+All dispatched actions return an `ActionResultModel` from `dcc-mcp-core`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `success` | `bool` | Whether the action completed successfully |
+| `message` | `str` | Human-readable result message |
+| `error` | `str \| None` | Error message if `success=False` |
+| `context` | `dict` | Arbitrary return data from the handler |
+
+```python
+result = adapter.call_action("create_sphere", radius=2.0)
+print(result.success)   # True
+print(result.message)   # "..."
+print(result.context)   # {...}
+data = result.to_dict() # Plain dict serialization
+```
+
+> **Migration**: `model_dump()` was renamed to `to_dict()` in v2.0.0.

--- a/docs/api/client.md
+++ b/docs/api/client.md
@@ -1,0 +1,62 @@
+# BaseDCCClient
+
+`BaseDCCClient` is the core client for connecting to and calling DCC servers.
+
+## Import
+
+```python
+from dcc_mcp_ipc.client import BaseDCCClient, get_client
+```
+
+## Constructor
+
+```python
+client = BaseDCCClient(
+    dcc_name: str,
+    host: str = "localhost",
+    port: int | None = None,         # None = auto-discover
+    connection_timeout: float = 10.0,
+)
+```
+
+## Methods
+
+| Method | Description |
+|--------|-------------|
+| `connect()` | Establish RPyC connection (auto-discovers port if not set) |
+| `disconnect()` | Close the connection |
+| `call(method, *args, **kwargs)` | Call a remote `exposed_<method>` on the service |
+| `execute_dcc_command(cmd)` | Execute a string command in the DCC |
+| `get_dcc_info()` | Retrieve DCC version/platform info |
+| `is_connected` | `bool` property |
+| `ensure_connected()` | Raise if not connected |
+
+## get_client Factory
+
+```python
+from dcc_mcp_ipc import get_client
+
+client = get_client("maya")  # returns cached client by name
+```
+
+## ClientRegistry
+
+```python
+from dcc_mcp_ipc.client import ClientRegistry
+
+ClientRegistry.register("maya_local", host="localhost", port=18812)
+client = ClientRegistry.get("maya_local")
+```
+
+## AsyncDCCClient
+
+For asyncio-based usage:
+
+```python
+from dcc_mcp_ipc.client.async_dcc import AsyncDCCClient
+
+client = AsyncDCCClient("maya", host="localhost", port=18812)
+await client.connect()
+result = await client.call("get_scene_info")
+await client.disconnect()
+```

--- a/docs/api/connection-pool.md
+++ b/docs/api/connection-pool.md
@@ -1,0 +1,35 @@
+# ConnectionPool
+
+`ConnectionPool` manages a pool of `BaseDCCClient` connections for efficient resource reuse.
+
+## Import
+
+```python
+from dcc_mcp_ipc.client import ConnectionPool
+```
+
+## Constructor
+
+```python
+pool = ConnectionPool(
+    max_connections: int = 5,
+    connection_timeout: float = 10.0,
+    idle_timeout: float = 300.0,
+)
+```
+
+## Usage
+
+```python
+with pool.get_client("maya", host="localhost", port=18812) as client:
+    result = client.call("get_scene_info")
+# Connection automatically returned to pool
+```
+
+## Methods
+
+| Method | Description |
+|--------|-------------|
+| `get_client(dcc_name, host, port)` | Context manager — acquires and returns a client |
+| `close()` | Close all pooled connections |
+| `size(dcc_name)` | Number of idle connections for a DCC |

--- a/docs/api/discovery.md
+++ b/docs/api/discovery.md
@@ -1,0 +1,59 @@
+# Discovery
+
+## ServiceDiscoveryFactory
+
+```python
+from dcc_mcp_ipc.discovery import ServiceDiscoveryFactory
+
+factory = ServiceDiscoveryFactory()
+strategy = factory.create()  # Auto-selects ZeroConf or file-based
+```
+
+## FileDiscoveryStrategy
+
+```python
+from dcc_mcp_ipc.discovery import FileDiscoveryStrategy
+
+strategy = FileDiscoveryStrategy()
+strategy.register("maya", "localhost", 18812)
+services = strategy.discover("maya")  # list[ServiceInfo]
+strategy.unregister("maya", "localhost", 18812)
+```
+
+## ZeroConfDiscoveryStrategy
+
+Requires `pip install "dcc-mcp-ipc[zeroconf]"`.
+
+```python
+from dcc_mcp_ipc.discovery import ZeroConfDiscoveryStrategy
+
+strategy = ZeroConfDiscoveryStrategy()
+strategy.register("maya", "localhost", 18812)
+services = strategy.discover("maya")
+strategy.unregister("maya", "localhost", 18812)
+```
+
+## ServiceRegistry
+
+In-memory registry of `ServiceInfo` objects:
+
+```python
+from dcc_mcp_ipc.discovery import ServiceRegistry, ServiceInfo
+
+registry = ServiceRegistry()
+registry.register(ServiceInfo(dcc_name="maya", host="localhost", port=18812))
+info = registry.get("maya")
+registry.unregister("maya")
+all_services = registry.list_all()  # list[ServiceInfo]
+```
+
+## ServiceInfo
+
+```python
+ServiceInfo(
+    dcc_name: str,
+    host: str,
+    port: int,
+    metadata: dict = {},
+)
+```

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -1,0 +1,61 @@
+# API Overview
+
+The public API is exposed via `dcc_mcp_ipc` with lazy imports. All symbols listed below are importable from the top-level package.
+
+## Exported Symbols
+
+```python
+from dcc_mcp_ipc import (
+    # Actions
+    ActionAdapter,
+
+    # Adapters
+    DCCAdapter,
+    ApplicationAdapter,
+
+    # Clients
+    BaseDCCClient,
+    BaseApplicationClient,
+    ConnectionPool,
+    ClientRegistry,
+
+    # Servers
+    DCCServer,
+    BaseRPyCService,
+    ApplicationRPyCService,
+
+    # Discovery
+    FileDiscoveryStrategy,
+    ZeroConfDiscoveryStrategy,
+    ServiceDiscoveryFactory,
+    ServiceRegistry,
+    ServiceInfo,
+
+    # Convenience helpers
+    get_adapter,
+    get_client,
+    start_server,
+    stop_server,
+    is_server_running,
+    DEFAULT_REGISTRY_PATH,
+)
+```
+
+## Module Reference
+
+| Module | Key Exports |
+|--------|-------------|
+| `dcc_mcp_ipc.action_adapter` | `ActionAdapter`, `get_action_adapter` |
+| `dcc_mcp_ipc.adapter` | `DCCAdapter`, `ApplicationAdapter`, `get_adapter` |
+| `dcc_mcp_ipc.client` | `BaseDCCClient`, `ConnectionPool`, `ClientRegistry`, `get_client` |
+| `dcc_mcp_ipc.client.async_dcc` | `AsyncDCCClient` |
+| `dcc_mcp_ipc.server` | `DCCServer`, `BaseRPyCService`, `create_dcc_server`, `start_server`, `stop_server`, `is_server_running` |
+| `dcc_mcp_ipc.server.factory` | `create_service_factory`, `create_shared_service_instance`, `create_raw_threaded_server` |
+| `dcc_mcp_ipc.transport` | `TransportFactory`, `IpcClientTransport`, `IpcServerTransport` |
+| `dcc_mcp_ipc.discovery` | `ServiceDiscoveryFactory`, `ServiceRegistry`, `ServiceInfo`, `FileDiscoveryStrategy`, `ZeroConfDiscoveryStrategy` |
+| `dcc_mcp_ipc.skills` | `SkillManager` |
+| `dcc_mcp_ipc.testing.mock_services` | `MockDCCService` |
+| `dcc_mcp_ipc.utils.rpyc_utils` | `deliver_parameters`, `execute_remote_command` |
+| `dcc_mcp_ipc.utils.errors` | `ActionError`, `handle_error` |
+
+For detailed documentation on each component, see the individual API pages.

--- a/docs/api/server.md
+++ b/docs/api/server.md
@@ -1,0 +1,98 @@
+# DCCServer
+
+`DCCServer` manages the RPyC server lifecycle inside a DCC process.
+
+## Import
+
+```python
+from dcc_mcp_ipc.server import (
+    DCCServer,
+    DCCRPyCService,
+    BaseRPyCService,
+    create_dcc_server,
+    create_service_factory,
+    create_shared_service_instance,
+    create_raw_threaded_server,
+    start_server,
+    stop_server,
+    is_server_running,
+)
+```
+
+## create_dcc_server
+
+```python
+server = create_dcc_server(
+    dcc_name: str,
+    service_class: type[BaseRPyCService],
+    port: int = 0,           # 0 = pick random available port
+    host: str = "localhost",
+) -> DCCServer
+```
+
+Convenience factory for the common case.
+
+## DCCServer
+
+```python
+server.start(threaded: bool = True) -> None
+server.stop() -> None
+server.is_running() -> bool
+server.port  # int — actual bound port
+```
+
+## BaseRPyCService / DCCRPyCService
+
+Subclass `DCCRPyCService` to implement your DCC service:
+
+```python
+from dcc_mcp_ipc.server import DCCRPyCService
+
+
+class MayaService(DCCRPyCService):
+    def exposed_get_scene_info(self, conn=None):
+        return {"scene": "my_scene.ma"}
+
+    def exposed_execute_cmd(self, cmd_name, *args, **kwargs):
+        import maya.cmds as cmds
+        return getattr(cmds, cmd_name)(*args, **kwargs)
+```
+
+All public methods must be prefixed with `exposed_` to be callable via RPyC.
+
+## Service Factories
+
+### create_service_factory
+
+Creates a new service instance per connection:
+
+```python
+factory = create_service_factory(MayaService, shared_manager)
+server = create_raw_threaded_server(factory, port=18812)
+server.start()
+```
+
+### create_shared_service_instance
+
+All connections share a single service instance:
+
+```python
+shared = create_shared_service_instance(MayaService, shared_manager)
+```
+
+### create_raw_threaded_server
+
+Direct `ThreadedServer` creation:
+
+```python
+server = create_raw_threaded_server(service_or_factory, port=18812)
+server.start()
+```
+
+## Module-level Lifecycle Helpers
+
+```python
+start_server("maya", MayaService, port=18812)
+is_server_running("maya")  # True
+stop_server("maya")
+```

--- a/docs/api/skill-manager.md
+++ b/docs/api/skill-manager.md
@@ -1,0 +1,83 @@
+# SkillManager
+
+`SkillManager` automates action registration from `SKILL.md` files. It wraps `SkillScanner` (filesystem scanning) and `SkillWatcher` (hot-reload via OS file events).
+
+## Import
+
+```python
+from dcc_mcp_ipc.skills import SkillManager
+```
+
+## Constructor
+
+```python
+mgr = SkillManager(
+    adapter: ActionAdapter,
+    dcc_name: str,
+)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `adapter` | `ActionAdapter` | The adapter to register discovered skills into |
+| `dcc_name` | `str` | DCC name used when executing skill scripts |
+
+## Methods
+
+### `load_paths`
+
+```python
+mgr.load_paths(paths: list[str]) -> None
+```
+
+Scan the given directories for `SKILL.md` files and register them as actions.
+
+### `load_from_env`
+
+```python
+mgr.load_from_env(env_var: str = "DCC_MCP_SKILL_PATHS") -> None
+```
+
+Read colon/semicolon-delimited paths from an environment variable and call `load_paths`.
+
+### `start_watching`
+
+```python
+mgr.start_watching() -> None
+```
+
+Start `SkillWatcher` to monitor loaded paths for file changes. Changes are debounced and trigger automatic re-registration.
+
+### `stop_watching`
+
+```python
+mgr.stop_watching() -> None
+```
+
+Stop the file watcher.
+
+### `list_skills`
+
+```python
+skills = mgr.list_skills() -> list[SkillInfo]
+```
+
+Return metadata for all currently registered skills.
+
+### `reload`
+
+```python
+mgr.reload() -> None
+```
+
+Manually trigger a re-scan and re-registration of all loaded paths.
+
+## SkillInfo
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | `str` | Skill name (from `SKILL.md` frontmatter) |
+| `path` | `str` | Absolute path to the skill directory |
+| `description` | `str` | Skill description |
+| `category` | `str` | Skill category |
+| `tags` | `list[str]` | Tags |

--- a/docs/api/transports.md
+++ b/docs/api/transports.md
@@ -1,0 +1,69 @@
+# Transports
+
+## TransportFactory
+
+```python
+from dcc_mcp_ipc.transport import TransportFactory
+
+transport = TransportFactory.create(
+    protocol: str,   # "rpyc" | "ipc" | "http" | "websocket"
+    host: str,
+    port: int,
+    **kwargs,
+) -> BaseTransport
+```
+
+## IpcClientTransport / IpcServerTransport
+
+```python
+from dcc_mcp_ipc.transport.ipc_transport import (
+    IpcClientTransport,
+    IpcServerTransport,
+    IpcTransportConfig,
+)
+
+# Client
+config = IpcTransportConfig(host="localhost", port=19000)
+client = IpcClientTransport(config)
+client.connect()
+result = client.execute("action_name", param=value)
+client.disconnect()
+
+# Server
+server = IpcServerTransport(addr, handler=my_handler)
+bound_addr = server.start()
+server.stop()
+```
+
+## HttpTransport
+
+```python
+from dcc_mcp_ipc.transport.http import HttpTransport
+
+t = HttpTransport(host="localhost", port=30010)
+t.connect()
+result = t.execute("get_scene_info")
+t.disconnect()
+```
+
+## WebSocketTransport
+
+```python
+from dcc_mcp_ipc.transport.websocket import WebSocketTransport
+
+t = WebSocketTransport(host="localhost", port=8765)
+t.connect()
+result = t.execute("list_actors")
+t.disconnect()
+```
+
+## BaseTransport
+
+All transports implement `BaseTransport`:
+
+| Method | Description |
+|--------|-------------|
+| `connect()` | Establish connection |
+| `disconnect()` | Close connection |
+| `execute(method, **kwargs)` | Execute remote call |
+| `is_connected` | `bool` property |

--- a/docs/examples/blender.md
+++ b/docs/examples/blender.md
@@ -1,0 +1,63 @@
+# Blender Integration
+
+## Setup
+
+Install `dcc-mcp-ipc` in Blender's bundled Python:
+
+```bash
+# Find Blender's Python
+/Applications/Blender.app/Contents/Resources/4.x/python/bin/python3.11 -m pip install dcc-mcp-ipc
+```
+
+## Server (Blender addon or script)
+
+```python
+import threading
+from dcc_mcp_ipc.server import create_dcc_server, DCCRPyCService
+
+
+class BlenderService(DCCRPyCService):
+    def exposed_get_scene_info(self, conn=None):
+        import bpy
+        return {
+            "file": bpy.data.filepath or "untitled",
+            "objects": [obj.name for obj in bpy.data.objects],
+            "frame": bpy.context.scene.frame_current,
+        }
+
+    def exposed_add_primitive(self, ptype="SPHERE", location=(0, 0, 0), conn=None):
+        import bpy
+        bpy.ops.mesh.primitive_uv_sphere_add(location=location)
+        obj = bpy.context.object
+        return {"success": True, "name": obj.name}
+
+    def exposed_execute_python(self, code, conn=None):
+        import bpy
+        local_vars = {}
+        exec(code, {"bpy": bpy}, local_vars)
+        return local_vars.get("_result")
+
+
+server = create_dcc_server(dcc_name="blender", service_class=BlenderService, port=18814)
+thread = threading.Thread(target=lambda: server.start(threaded=False), daemon=True)
+thread.start()
+print("Blender IPC server started on port 18814")
+```
+
+## Client
+
+```python
+from dcc_mcp_ipc.client import BaseDCCClient
+
+client = BaseDCCClient("blender", host="localhost", port=18814)
+client.connect()
+
+info = client.call("get_scene_info")
+print(f"File: {info['file']}")
+print(f"Objects: {info['objects']}")
+
+result = client.call("add_primitive", ptype="SPHERE", location=[1, 0, 0])
+print(f"Created: {result['name']}")
+
+client.disconnect()
+```

--- a/docs/examples/houdini.md
+++ b/docs/examples/houdini.md
@@ -1,0 +1,57 @@
+# Houdini Integration
+
+## Setup
+
+Install `dcc-mcp-ipc` using Houdini's Python interpreter:
+
+```bash
+hython -m pip install dcc-mcp-ipc
+```
+
+## Server (Houdini Python Shell or startup script)
+
+```python
+from dcc_mcp_ipc.server import create_dcc_server, DCCRPyCService
+
+
+class HoudiniService(DCCRPyCService):
+    def exposed_get_scene_info(self, conn=None):
+        import hou
+        return {
+            "file": hou.hipFile.path(),
+            "nodes": len(hou.node("/obj").children()),
+            "fps": hou.fps(),
+        }
+
+    def exposed_create_geo(self, name="geo1", conn=None):
+        import hou
+        obj = hou.node("/obj").createNode("geo", name)
+        return {"success": True, "path": obj.path()}
+
+    def exposed_execute_python(self, code, conn=None):
+        local_vars = {}
+        exec(code, {"hou": __import__("hou")}, local_vars)
+        return local_vars.get("_result")
+
+
+server = create_dcc_server(dcc_name="houdini", service_class=HoudiniService, port=18813)
+server.start(threaded=True)
+print("Houdini IPC server started on port 18813")
+```
+
+## Client
+
+```python
+from dcc_mcp_ipc.client import BaseDCCClient
+
+client = BaseDCCClient("houdini", host="localhost", port=18813)
+client.connect()
+
+info = client.call("get_scene_info")
+print(f"File: {info['file']}, Nodes: {info['nodes']}")
+
+result = client.call("create_geo", name="myGeo")
+print(f"Created: {result['path']}")
+
+client.disconnect()
+```

--- a/docs/examples/maya.md
+++ b/docs/examples/maya.md
@@ -1,0 +1,99 @@
+# Maya Integration
+
+## Setup
+
+1. Install `dcc-mcp-ipc` in Maya's Python environment:
+
+```bash
+mayapy -m pip install dcc-mcp-ipc
+```
+
+2. Add the server startup to Maya's `userSetup.py`:
+
+```python
+# ~/maya/scripts/userSetup.py
+import maya.utils as utils
+
+
+def start_mcp_server():
+    from dcc_mcp_ipc.server import create_dcc_server, DCCRPyCService
+
+    class MayaService(DCCRPyCService):
+        def exposed_execute_mel(self, command, conn=None):
+            import maya.mel as mel
+            return mel.eval(command)
+
+        def exposed_execute_python(self, code, conn=None):
+            local_vars = {}
+            exec(code, {"cmds": __import__("maya.cmds", fromlist=["cmds"])}, local_vars)
+            return local_vars.get("_result")
+
+        def exposed_get_scene_info(self, conn=None):
+            import maya.cmds as cmds
+            return {
+                "scene": cmds.file(query=True, sceneName=True) or "untitled",
+                "objects": cmds.ls(type="transform"),
+                "cameras": cmds.ls(type="camera"),
+            }
+
+        def exposed_create_object(self, obj_type, name=None, conn=None):
+            import maya.cmds as cmds
+            kwargs = {"name": name} if name else {}
+            result = getattr(cmds, obj_type)(**kwargs)
+            return {"success": True, "name": result[0] if isinstance(result, list) else result}
+
+    server = create_dcc_server(dcc_name="maya", service_class=MayaService, port=18812)
+    server.start(threaded=True)
+    print("[dcc-mcp-ipc] Maya server started on port 18812")
+
+
+utils.executeDeferred(start_mcp_server)
+```
+
+## Connecting from MCP Server
+
+```python
+from dcc_mcp_ipc.client import BaseDCCClient
+
+client = BaseDCCClient("maya", host="localhost", port=18812)
+client.connect()
+
+# Execute MEL
+client.call("execute_mel", "polySphere -r 1 -n mySphere;")
+
+# Execute Python
+client.call("execute_python", "import maya.cmds; maya.cmds.polySphere(); _result = 'done'")
+
+# Get scene info
+info = client.call("get_scene_info")
+print(info)
+
+client.disconnect()
+```
+
+## Maya Action Adapter
+
+```python
+from dcc_mcp_ipc.action_adapter import get_action_adapter
+from dcc_mcp_ipc.client import BaseDCCClient
+
+client = BaseDCCClient("maya", host="localhost", port=18812)
+client.connect()
+adapter = get_action_adapter("maya")
+
+
+def create_primitive(ptype: str = "sphere", radius: float = 1.0, name: str = "shape1") -> dict:
+    """Create a polygon primitive in Maya."""
+    cmd_map = {"sphere": "polySphere", "cube": "polyCube", "cylinder": "polyCylinder"}
+    cmd = cmd_map.get(ptype, "polySphere")
+    return client.call("create_object", cmd, name=name)
+
+
+adapter.register_action(
+    "create_primitive",
+    create_primitive,
+    description="Create a polygon primitive in Maya",
+    category="modeling",
+    tags=["primitive", "polygon", "maya"],
+)
+```

--- a/docs/examples/quickstart.md
+++ b/docs/examples/quickstart.md
@@ -1,0 +1,76 @@
+# Quick Start Example
+
+A minimal end-to-end example: a DCC server and an MCP client.
+
+## Server (runs inside DCC)
+
+```python
+# maya_server.py — run inside Maya's script editor or startup hook
+from dcc_mcp_ipc.server import create_dcc_server, DCCRPyCService
+
+
+class MayaService(DCCRPyCService):
+    def exposed_get_scene_info(self, conn=None):
+        import maya.cmds as cmds
+        return {
+            "scene": cmds.file(query=True, sceneName=True),
+            "objects": len(cmds.ls()),
+        }
+
+    def exposed_create_sphere(self, radius=1.0, name="sphere1", conn=None):
+        import maya.cmds as cmds
+        cmds.polySphere(r=radius, name=name)
+        return {"success": True, "name": name}
+
+
+server = create_dcc_server(dcc_name="maya", service_class=MayaService, port=18812)
+server.start(threaded=True)
+print("Maya IPC server started on port 18812")
+```
+
+## Client (runs in MCP server process)
+
+```python
+# mcp_handler.py
+from dcc_mcp_ipc.client import BaseDCCClient
+
+client = BaseDCCClient("maya", host="localhost", port=18812)
+client.connect()
+
+info = client.call("get_scene_info")
+print(f"Scene: {info['scene']}, Objects: {info['objects']}")
+
+result = client.call("create_sphere", radius=2.0, name="bigSphere")
+print(f"Created: {result['name']}")
+
+client.disconnect()
+```
+
+## Using Action System
+
+```python
+# actions.py — register MCP tools as named actions
+from dcc_mcp_ipc.action_adapter import get_action_adapter
+from dcc_mcp_ipc.client import BaseDCCClient
+
+client = BaseDCCClient("maya", host="localhost", port=18812)
+client.connect()
+
+adapter = get_action_adapter("maya")
+
+
+def create_sphere(radius: float = 1.0, name: str = "sphere1") -> dict:
+    return client.call("create_sphere", radius=radius, name=name)
+
+
+adapter.register_action(
+    "maya_create_sphere",
+    create_sphere,
+    description="Create a sphere in Maya",
+    category="modeling",
+    tags=["primitive", "mesh"],
+)
+
+result = adapter.call_action("maya_create_sphere", radius=3.0)
+print(result.to_dict())
+```

--- a/docs/examples/service-factories.md
+++ b/docs/examples/service-factories.md
@@ -1,0 +1,65 @@
+# Service Factories
+
+Service factories give you control over how service instances are created for each connection.
+
+## Pattern 1: Per-connection Instance
+
+Each client connection gets its own service instance. Use this when services hold connection-specific state:
+
+```python
+from dcc_mcp_ipc.server import create_service_factory, create_raw_threaded_server, DCCRPyCService
+
+
+class SessionManager:
+    def __init__(self):
+        self.active_selections = []
+
+
+class MayaService(DCCRPyCService):
+    def __init__(self, session_manager):
+        self.sessions = session_manager
+
+    def exposed_select(self, obj_name, conn=None):
+        self.sessions.active_selections.append(obj_name)
+        return {"selected": obj_name}
+
+
+shared_manager = SessionManager()
+service_factory = create_service_factory(MayaService, shared_manager)
+server = create_raw_threaded_server(service_factory, port=18812)
+server.start()
+```
+
+## Pattern 2: Shared Instance
+
+All connections share a single service instance. Use this for stateless services or when sharing a thread-safe resource:
+
+```python
+from dcc_mcp_ipc.server import create_shared_service_instance, create_raw_threaded_server
+
+
+shared_service = create_shared_service_instance(MayaService, shared_manager)
+server = create_raw_threaded_server(shared_service, port=18812)
+server.start()
+```
+
+## Pattern 3: Module-level Lifecycle Helpers
+
+```python
+from dcc_mcp_ipc.server import start_server, stop_server, is_server_running
+
+
+start_server("maya", MayaService, port=18812)
+print(is_server_running("maya"))  # True
+
+stop_server("maya")
+print(is_server_running("maya"))  # False
+```
+
+## When to Use Each Pattern
+
+| Pattern | Use When |
+|---------|----------|
+| Per-connection | Service holds per-connection state (selections, undo history, etc.) |
+| Shared | Service is stateless or wraps a thread-safe shared resource |
+| Module-level helpers | You want a simple global server registry |

--- a/docs/examples/skills.md
+++ b/docs/examples/skills.md
@@ -1,0 +1,135 @@
+# Skills Example
+
+This example shows a complete zero-code MCP skill setup for Maya.
+
+## Directory Structure
+
+```
+pipeline_skills/
+├── create_sphere/
+│   ├── SKILL.md
+│   └── run.py
+├── render_frame/
+│   ├── SKILL.md
+│   └── run.py
+└── export_selection/
+    ├── SKILL.md
+    └── run.py
+```
+
+## create_sphere/SKILL.md
+
+```markdown
+---
+name: create_sphere
+description: Create a polygonal sphere in Maya at the specified position
+category: modeling
+tags:
+  - primitive
+  - mesh
+parameters:
+  radius:
+    type: float
+    default: 1.0
+    description: Sphere radius in Maya units
+  name:
+    type: string
+    default: pSphere1
+    description: Name for the created object
+  subdivisions_axis:
+    type: int
+    default: 20
+    description: Number of subdivisions around the axis
+  subdivisions_height:
+    type: int
+    default: 20
+    description: Number of subdivisions along the height
+---
+
+Creates a polygon sphere with the specified parameters.
+```
+
+## create_sphere/run.py
+
+```python
+# Parameters injected from SKILL.md: radius, name, subdivisions_axis, subdivisions_height
+import maya.cmds as cmds
+
+transforms = cmds.polySphere(
+    r=radius,
+    n=name,
+    sx=subdivisions_axis,
+    sy=subdivisions_height,
+)[0]
+
+result = {
+    "success": True,
+    "name": transforms,
+    "radius": radius,
+}
+```
+
+## render_frame/SKILL.md
+
+```markdown
+---
+name: render_frame
+description: Render the current frame in Maya using the active renderer
+category: rendering
+tags:
+  - render
+  - output
+parameters:
+  output_path:
+    type: string
+    default: ""
+    description: Output file path (empty = use render settings)
+  width:
+    type: int
+    default: 0
+    description: Override render width (0 = use render settings)
+  height:
+    type: int
+    default: 0
+    description: Override render height (0 = use render settings)
+---
+```
+
+## render_frame/run.py
+
+```python
+import maya.cmds as cmds
+
+if width > 0:
+    cmds.setAttr("defaultResolution.width", width)
+if height > 0:
+    cmds.setAttr("defaultResolution.height", height)
+
+cmds.render(batch=True)
+
+result = {
+    "success": True,
+    "frame": cmds.currentTime(query=True),
+    "output_path": cmds.renderSettings(firstImageName=True)[0],
+}
+```
+
+## Registering Skills
+
+```python
+from dcc_mcp_ipc.skills import SkillManager
+from dcc_mcp_ipc.action_adapter import get_action_adapter
+
+adapter = get_action_adapter("maya")
+mgr = SkillManager(adapter=adapter, dcc_name="maya")
+
+mgr.load_paths(["./pipeline_skills"])
+mgr.start_watching()
+
+# Now usable as MCP tools
+result = adapter.call_action("create_sphere", radius=3.0, name="bigSphere")
+print(result.success)
+
+result = adapter.call_action("render_frame", width=1920, height=1080)
+print(result.to_dict())
+```

--- a/docs/guide/action-system.md
+++ b/docs/guide/action-system.md
@@ -1,0 +1,111 @@
+# Action System
+
+The Action System is the central mechanism for registering and dispatching callable operations (MCP tools) in DCC-MCP-IPC. It is backed by the Rust/PyO3 core from `dcc-mcp-core`.
+
+## Overview
+
+```
+ActionAdapter
+├── ActionRegistry (Rust)   — stores action metadata and handlers
+└── ActionDispatcher (Rust) — dispatches calls with JSON-serialised params
+```
+
+`ActionResultModel` (from `dcc-mcp-core`) is the uniform return type for all dispatched calls.
+
+## Getting an ActionAdapter
+
+```python
+from dcc_mcp_ipc.action_adapter import get_action_adapter
+
+adapter = get_action_adapter("maya")  # cached singleton by name
+```
+
+`get_action_adapter(name)` returns the same instance every time for the same name.
+
+## Registering Actions
+
+```python
+def create_sphere(radius: float = 1.0, name: str = "sphere1") -> dict:
+    """Create a sphere primitive."""
+    # Your DCC-specific implementation
+    return {
+        "success": True,
+        "message": f"Created '{name}' with radius {radius}",
+        "context": {"name": name, "radius": radius},
+    }
+
+
+adapter.register_action(
+    "create_sphere",
+    create_sphere,
+    description="Create a sphere primitive in the scene",
+    category="modeling",
+    tags=["primitive", "mesh", "geometry"],
+)
+```
+
+Parameters:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | `str` | Unique action identifier (used as MCP tool name) |
+| `handler` | `Callable` | The function to call when dispatched |
+| `description` | `str` | Human-readable description for MCP tool registration |
+| `category` | `str` | Logical grouping (e.g., `"modeling"`, `"rendering"`) |
+| `tags` | `list[str]` | Searchable tags |
+
+## Dispatching Actions
+
+```python
+result = adapter.call_action("create_sphere", radius=2.0, name="mySphere")
+```
+
+All keyword arguments are JSON-serialised before being passed to the Rust dispatcher. The handler function receives them as normal Python arguments.
+
+## ActionResultModel
+
+All dispatched actions return an `ActionResultModel` from `dcc-mcp-core`:
+
+```python
+result = adapter.call_action("create_sphere", radius=2.0)
+
+print(result.success)   # bool
+print(result.message)   # str — human-readable message
+print(result.error)     # str | None — error message if failed
+print(result.context)   # dict — arbitrary return data
+
+# Serialise to plain dict
+data = result.to_dict()
+```
+
+> **Note**: In v2.0.0, `model_dump()` was renamed to `to_dict()`. Update any code using the old name.
+
+## Error Handling
+
+If the handler raises an exception, the dispatcher returns an `ActionResultModel` with `success=False` and the error message populated:
+
+```python
+def risky_action() -> dict:
+    raise ValueError("Something went wrong")
+
+adapter.register_action("risky", risky_action, description="A risky action")
+
+result = adapter.call_action("risky")
+print(result.success)  # False
+print(result.error)    # "Something went wrong"
+```
+
+## Listing Available Actions
+
+```python
+actions = adapter.list_actions()
+for action in actions:
+    print(action.name, action.description, action.category)
+```
+
+## Best Practices
+
+- **Use descriptive names** — action names become MCP tool names visible to the AI.
+- **Document parameters** — include type hints and docstrings; they're surfaced in MCP tool schemas.
+- **Return structured data** — always return a dict with `success`, `message`, and optionally `context`.
+- **Categories** — group related actions with consistent category names for better discoverability.

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -1,0 +1,139 @@
+# Architecture
+
+## Component Overview
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                   AI Assistant / MCP Client              │
+└─────────────────────────┬───────────────────────────────┘
+                          │ MCP protocol
+┌─────────────────────────▼───────────────────────────────┐
+│                      MCP Server                         │
+└─────────────────────────┬───────────────────────────────┘
+                          │
+┌─────────────────────────▼───────────────────────────────┐
+│                   ActionAdapter                         │
+│  ┌──────────────────┐    ┌──────────────────────────┐   │
+│  │  ActionRegistry  │    │   ActionDispatcher        │   │
+│  │  (Rust/PyO3)     │    │   (Rust/PyO3)            │   │
+│  └──────────────────┘    └──────────────────────────┘   │
+│               ▲                                          │
+│               │  registers                               │
+│  ┌────────────┴─────────────────────────────────────┐   │
+│  │  SkillManager                                    │   │
+│  │  ┌─────────────────┐  ┌────────────────────────┐ │   │
+│  │  │  SkillScanner   │  │  SkillWatcher (FSEvents)│ │   │
+│  │  └─────────────────┘  └────────────────────────┘ │   │
+│  └──────────────────────────────────────────────────┘   │
+└─────────────────────────┬───────────────────────────────┘
+                          │
+        ┌─────────────────┼─────────────────┐
+        │                 │                 │
+   RPyC Transport    IPC Transport    HTTP Transport
+        │                 │                 │
+   DCC Application   DCC Application  REST API
+   (Maya/Houdini/    (Rust plugin)    (Unreal/Unity)
+    Blender)
+```
+
+## Package Layout
+
+```
+src/dcc_mcp_ipc/
+├── __init__.py              # Lazy-import public API (37 exports)
+├── action_adapter.py         # ActionAdapter + get_action_adapter()
+├── adapter/                  # DCCAdapter, ApplicationAdapter
+├── client/                   # BaseDCCClient, ConnectionPool, AsyncDCCClient
+├── server/                   # DCCServer, BaseRPyCService, factories
+├── transport/                # Transport factory + RPyC/HTTP/WS/IPC impl.
+├── discovery/                # ServiceDiscoveryFactory, ZeroConf, file-based
+├── skills/                   # SkillManager, SkillScanner
+├── scene/                    # Scene interface (RPyC + HTTP)
+├── snapshot/                 # Snapshot interface (RPyC + HTTP)
+├── application/              # ApplicationAdapter/Service/Client
+├── testing/                  # MockDCCService
+└── utils/                    # Errors, DI, decorators, rpyc_utils
+```
+
+## Layers
+
+### 1. Action Layer (`action_adapter.py`)
+
+The `ActionAdapter` is the central registry for callable operations:
+
+- Wraps `ActionRegistry` (Rust) for storing handler metadata
+- Wraps `ActionDispatcher` (Rust) for dispatching calls with JSON-serialised parameters
+- Factory function `get_action_adapter(name)` returns a cached adapter per DCC name
+- `ActionResultModel` (from `dcc-mcp-core`) is the uniform return type
+
+### 2. Skills Layer (`skills/`)
+
+`SkillManager` automates action registration from filesystem:
+
+- `SkillScanner` walks directories looking for `SKILL.md` files
+- `SkillWatcher` uses OS filesystem events (debounced) to detect changes
+- Each skill corresponds to a `run.py` script executed with injected parameters
+- Hot-reload: file changes trigger re-scan and re-registration without DCC restart
+
+### 3. Transport Layer (`transport/`)
+
+| Transport | Protocol | Target DCCs |
+|-----------|----------|-------------|
+| `RpycTransport` | RPyC (TCP) | Maya, Houdini, Blender, 3ds Max, Nuke |
+| `IpcClientTransport` / `IpcServerTransport` | Rust FramedChannel (named pipe / Unix socket) | Rust-based DCC plugins |
+| `HttpTransport` | REST over HTTP | Unreal Engine, Unity |
+| `WebSocketTransport` | WebSocket | Any WebSocket-capable DCC |
+
+The `TransportFactory` resolves the correct transport from a protocol string.
+
+### 4. Discovery Layer (`discovery/`)
+
+`ServiceDiscoveryFactory` selects a strategy:
+
+- **ZeroConf** (`ZeroConfDiscoveryStrategy`): mDNS/DNS-SD — requires `zeroconf` extra
+- **File-based** (`FileDiscoveryStrategy`): JSON registry file at `get_config_dir()` — cross-platform fallback
+
+`ServiceRegistry` holds discovered `ServiceInfo` objects (DCC name, host, port, metadata).
+
+### 5. Server Layer (`server/`)
+
+- `DCCServer`: owns the RPyC `ThreadedServer`, manages start/stop lifecycle
+- `BaseRPyCService`: abstract base for all RPyC services
+- `DCCRPyCService`: concrete service with standard `exposed_*` API
+- Factory functions: `create_service_factory`, `create_shared_service_instance`, `create_raw_threaded_server`
+- Lifecycle helpers: `start_server`, `stop_server`, `is_server_running`
+
+### 6. Client Layer (`client/`)
+
+- `BaseDCCClient`: connects to a named DCC server via auto-discovery or explicit host/port
+- `ConnectionPool`: manages a pool of `BaseDCCClient` connections
+- `ClientRegistry`: global registry of all named clients
+- `AsyncDCCClient` / `AsyncBaseClient`: asyncio variants for non-blocking operations
+
+### 7. Adapter Layer (`adapter/`)
+
+- `DCCAdapter`: abstract base — subclass and implement `_initialize_client()` for DCC-specific client setup
+- `ApplicationAdapter`: generic app adapter for non-DCC use cases
+- `get_adapter(name)` factory — returns cached adapter instance
+
+## Data Flow: Action Dispatch
+
+```
+MCP Tool Call ("create_sphere", {radius: 2.0})
+    │
+    ▼
+ActionAdapter.call_action("create_sphere", radius=2.0)
+    │
+    ▼
+ActionDispatcher.dispatch("create_sphere", json_params)  [Rust]
+    │
+    ▼
+Registered handler function:
+    create_sphere(radius=2.0)
+    │
+    ▼
+ActionResultModel(success=True, message="...", context={...})  [Rust]
+    │
+    ▼
+Result returned to MCP client
+```

--- a/docs/guide/async-client.md
+++ b/docs/guide/async-client.md
@@ -1,0 +1,65 @@
+# Async Client
+
+DCC-MCP-IPC includes an asyncio-based client (`AsyncDCCClient`) for non-blocking operations in async MCP server frameworks.
+
+## AsyncDCCClient
+
+```python
+import asyncio
+from dcc_mcp_ipc.client.async_dcc import AsyncDCCClient
+
+
+async def main():
+    client = AsyncDCCClient("maya", host="localhost", port=18812)
+    await client.connect()
+
+    result = await client.call("get_scene_info")
+    print(result)
+
+    await client.disconnect()
+
+
+asyncio.run(main())
+```
+
+## Concurrent Calls
+
+```python
+import asyncio
+from dcc_mcp_ipc.client.async_dcc import AsyncDCCClient
+
+
+async def main():
+    client = AsyncDCCClient("maya", host="localhost", port=18812)
+    await client.connect()
+
+    # Run multiple calls concurrently
+    results = await asyncio.gather(
+        client.call("get_scene_info"),
+        client.call("list_objects"),
+        client.call("get_render_settings"),
+    )
+    print(results)
+
+    await client.disconnect()
+```
+
+## AsyncBaseClient
+
+`AsyncBaseClient` is the abstract base; subclass it to create DCC-specific async clients:
+
+```python
+from dcc_mcp_ipc.client.async_base import AsyncBaseClient
+
+
+class MayaAsyncClient(AsyncBaseClient):
+    async def create_sphere(self, radius: float = 1.0, name: str = "sphere1"):
+        return await self.call("create_sphere", radius=radius, name=name)
+```
+
+## When to Use Async
+
+Use the async client when:
+- Your MCP server framework is async (e.g., `fastmcp`, `mcp[cli]` with async handlers)
+- You need to make multiple concurrent DCC calls
+- You want to avoid blocking the event loop during RPyC network I/O

--- a/docs/guide/connection-pool.md
+++ b/docs/guide/connection-pool.md
@@ -1,0 +1,49 @@
+# Connection Pool
+
+`ConnectionPool` manages a pool of `BaseDCCClient` connections for efficient resource reuse. It is useful when your MCP server handles many concurrent requests to the same DCC application.
+
+## Basic Usage
+
+```python
+from dcc_mcp_ipc.client import ConnectionPool
+
+pool = ConnectionPool()
+
+# Acquire a client (creates new if none available)
+with pool.get_client("maya", host="localhost", port=18812) as client:
+    result = client.call("get_scene_info")
+    print(result)
+# Connection is automatically returned to the pool
+```
+
+## Configuration
+
+```python
+pool = ConnectionPool(
+    max_connections=10,       # max connections per DCC name
+    connection_timeout=30.0,  # seconds to wait for a connection
+    idle_timeout=300.0,       # seconds before idle connections are closed
+)
+```
+
+## ClientRegistry
+
+`ClientRegistry` provides a global named registry of clients:
+
+```python
+from dcc_mcp_ipc.client import ClientRegistry, get_client
+
+# Register a named client
+ClientRegistry.register("maya_prod", host="maya-server-01", port=18812)
+
+# Retrieve by name
+client = get_client("maya_prod")
+client.connect()
+result = client.call("get_scene_info")
+```
+
+## Best Practices
+
+- Use a single `ConnectionPool` instance per process (make it a module-level singleton or inject it via DI).
+- Use the context manager (`with pool.get_client(...)`) to ensure connections are always returned.
+- Set `max_connections` to match the number of worker threads in your MCP server.

--- a/docs/guide/custom-adapters.md
+++ b/docs/guide/custom-adapters.md
@@ -1,0 +1,92 @@
+# Custom Adapters
+
+`DCCAdapter` is an abstract base class for creating DCC-specific Python APIs. It wraps a `BaseDCCClient` and provides a clean interface for DCC operations.
+
+## Creating a DCCAdapter
+
+```python
+from dcc_mcp_ipc.adapter import DCCAdapter
+from dcc_mcp_ipc.client import BaseDCCClient
+
+
+class MayaAdapter(DCCAdapter):
+    def _initialize_client(self) -> None:
+        """Create and configure the underlying client."""
+        self.client = BaseDCCClient(
+            dcc_name="maya",
+            host=self.host,
+            port=self.port,
+            connection_timeout=self.connection_timeout,
+        )
+
+    # DCC-specific methods
+    def create_sphere(self, radius: float = 1.0, name: str = "sphere1"):
+        self.ensure_connected()
+        assert self.client is not None
+        return self.client.execute_dcc_command(f"polySphere -r {radius} -n {name};")
+
+    def get_scene_info(self):
+        self.ensure_connected()
+        assert self.client is not None
+        return self.client.call("get_scene_info")
+
+    def list_objects(self, obj_type: str = "transform"):
+        self.ensure_connected()
+        assert self.client is not None
+        return self.client.call("list_objects", obj_type=obj_type)
+```
+
+## Using the Adapter
+
+```python
+adapter = MayaAdapter(host="localhost", port=18812)
+adapter.connect()
+
+info = adapter.get_scene_info()
+result = adapter.create_sphere(radius=2.0, name="bigSphere")
+
+adapter.disconnect()
+```
+
+## ApplicationAdapter
+
+For non-DCC applications (generic REST services, etc.), use `ApplicationAdapter`:
+
+```python
+from dcc_mcp_ipc.adapter import ApplicationAdapter
+
+adapter = ApplicationAdapter(host="localhost", port=9000)
+adapter.connect()
+result = adapter.execute("some_action", param1="value")
+```
+
+## get_adapter() Factory
+
+```python
+from dcc_mcp_ipc import get_adapter
+
+adapter = get_adapter("maya")  # returns a cached DCCAdapter instance
+```
+
+## DCCAdapter API Reference
+
+| Method | Description |
+|--------|-------------|
+| `connect()` | Establish connection to the DCC server |
+| `disconnect()` | Close the connection |
+| `ensure_connected()` | Raises if not connected |
+| `is_connected` | bool property |
+| `_initialize_client()` | **Abstract** — implement to create `self.client` |
+
+## ApplicationRPyCService
+
+For server-side generic application services:
+
+```python
+from dcc_mcp_ipc.application import ApplicationRPyCService
+
+
+class MyAppService(ApplicationRPyCService):
+    def exposed_get_status(self):
+        return {"status": "running", "uptime": 3600}
+```

--- a/docs/guide/discovery.md
+++ b/docs/guide/discovery.md
@@ -1,0 +1,114 @@
+# Service Discovery
+
+Service discovery lets MCP clients automatically find running DCC servers without hardcoding host/port values. DCC-MCP-IPC supports two discovery strategies.
+
+## Strategies
+
+| Strategy | Class | How it works |
+|----------|-------|--------------|
+| **ZeroConf** | `ZeroConfDiscoveryStrategy` | Advertises/discovers via mDNS/DNS-SD on the local network |
+| **File-based** | `FileDiscoveryStrategy` | Reads/writes a JSON registry file at a well-known path |
+
+The `ServiceDiscoveryFactory` selects the strategy automatically based on availability:
+
+```python
+from dcc_mcp_ipc.discovery import ServiceDiscoveryFactory
+
+factory = ServiceDiscoveryFactory()
+strategy = factory.create()  # ZeroConf if available, else file-based
+```
+
+## ZeroConf Discovery
+
+Requires the `zeroconf` extra:
+
+```bash
+pip install "dcc-mcp-ipc[zeroconf]"
+```
+
+### Server-side registration
+
+```python
+from dcc_mcp_ipc.discovery import ZeroConfDiscoveryStrategy
+
+strategy = ZeroConfDiscoveryStrategy()
+strategy.register("maya", "localhost", 18812, metadata={"version": "2025"})
+```
+
+### Client-side lookup
+
+```python
+services = strategy.discover("maya")
+for svc in services:
+    print(svc.dcc_name, svc.host, svc.port)
+```
+
+## File-based Discovery
+
+Uses a JSON registry file stored in the OS config directory (resolved by `dcc_mcp_core.get_config_dir()`).
+
+```python
+from dcc_mcp_ipc.discovery import FileDiscoveryStrategy
+
+strategy = FileDiscoveryStrategy()
+strategy.register("maya", "localhost", 18812)
+
+services = strategy.discover("maya")
+```
+
+The registry file lives at `{config_dir}/dcc_mcp_ipc/registry.json`.
+
+## ServiceRegistry
+
+`ServiceRegistry` is an in-memory store for discovered `ServiceInfo` objects:
+
+```python
+from dcc_mcp_ipc.discovery import ServiceRegistry, ServiceInfo
+
+registry = ServiceRegistry()
+registry.register(ServiceInfo(dcc_name="maya", host="localhost", port=18812))
+
+info = registry.get("maya")
+print(info.host, info.port)
+
+registry.unregister("maya")
+```
+
+## ServiceInfo
+
+```python
+from dcc_mcp_ipc.discovery import ServiceInfo
+
+info = ServiceInfo(
+    dcc_name="maya",
+    host="localhost",
+    port=18812,
+    metadata={"version": "2025", "os": "windows"},
+)
+
+print(info.dcc_name)  # "maya"
+print(info.host)      # "localhost"
+print(info.port)      # 18812
+```
+
+## Discovery in BaseDCCClient
+
+`BaseDCCClient` uses discovery automatically when no explicit port is provided:
+
+```python
+from dcc_mcp_ipc.client import BaseDCCClient
+
+# Auto-discover the Maya server
+client = BaseDCCClient("maya", host="localhost")
+client.connect()
+```
+
+## DEFAULT_REGISTRY_PATH
+
+The default registry file path is exposed as a module constant:
+
+```python
+from dcc_mcp_ipc import DEFAULT_REGISTRY_PATH
+
+print(DEFAULT_REGISTRY_PATH)  # e.g., ~/.config/dcc_mcp_ipc/registry.json
+```

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -1,0 +1,55 @@
+# Installation
+
+## Requirements
+
+| Dependency | Version | Notes |
+|------------|---------|-------|
+| Python | >= 3.8, < 4.0 | |
+| dcc-mcp-core | >= 0.12.0, < 1.0.0 | Rust/PyO3 backend — installed automatically |
+| rpyc | >= 6.0.0, < 7.0.0 | Remote Python Call transport |
+| zeroconf | >= 0.38.0 | *Optional* — for mDNS service discovery |
+
+## Install from PyPI
+
+```bash
+pip install dcc-mcp-ipc
+```
+
+### With ZeroConf support
+
+ZeroConf enables automatic mDNS-based service discovery so clients can find DCC servers without manual configuration:
+
+```bash
+pip install "dcc-mcp-ipc[zeroconf]"
+```
+
+## Install with Poetry
+
+```bash
+poetry add dcc-mcp-ipc
+```
+
+With ZeroConf:
+
+```bash
+poetry add "dcc-mcp-ipc[zeroconf]"
+```
+
+## Development Installation
+
+```bash
+git clone https://github.com/loonghao/dcc-mcp-ipc.git
+cd dcc-mcp-ipc
+poetry install
+```
+
+This installs the package in editable mode along with all development dependencies.
+
+## Verify Installation
+
+```python
+import dcc_mcp_ipc
+print(dir(dcc_mcp_ipc))
+```
+
+You should see the public API surface including `ActionAdapter`, `DCCServer`, `BaseDCCClient`, `SkillManager`, etc.

--- a/docs/guide/introduction.md
+++ b/docs/guide/introduction.md
@@ -1,0 +1,65 @@
+# Introduction
+
+**DCC-MCP-IPC** is a multi-protocol IPC adapter layer that bridges DCC (Digital Content Creation) applications — such as Maya, Houdini, Blender, Unreal Engine, and Unity — with the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/).
+
+It is built on top of **[dcc-mcp-core](https://pypi.org/project/dcc-mcp-core/)** (a Rust/PyO3 backend) and exposes DCC functionality as MCP tools via pluggable transport protocols.
+
+## What Problem Does It Solve?
+
+AI assistants (Claude, GPT-4, etc.) can use MCP tools to interact with external software. However, DCC applications each have their own scripting APIs, inter-process communication mechanisms, and plugin models. Without a unified adapter, you'd need a separate MCP integration for each DCC.
+
+DCC-MCP-IPC provides:
+
+1. **A single API surface** — `ActionAdapter`, `SkillManager`, transports — regardless of the underlying DCC or protocol.
+2. **Zero-code skill registration** — write a `SKILL.md` file instead of a full Python MCP tool implementation.
+3. **Performance** — Rust-native IPC transport for latency-sensitive operations; RPyC for DCC-embedded Python; HTTP/WebSocket for REST-based DCCs.
+
+## How It Works
+
+```
+AI Assistant (MCP Client)
+        ↓
+    MCP Server
+        ↓
+  ActionAdapter  ←──  SkillManager (SKILL.md auto-discovery)
+        ↓
+  Transport Layer
+    ├── RPyC   → Maya / Houdini / Blender (embedded Python)
+    ├── IPC    → Rust-native FramedChannel (low-latency)
+    ├── HTTP   → Unreal Engine / Unity (REST API)
+    └── WS     → WebSocket-based services
+```
+
+The **ActionAdapter** wraps the Rust `ActionRegistry` and `ActionDispatcher` from `dcc-mcp-core`. Actions are registered with a name, handler function, description, category, and tags. When an MCP tool call arrives, the adapter dispatches it with JSON-serialised parameters.
+
+The **SkillManager** makes this even simpler: drop a `SKILL.md` file with frontmatter metadata into a directory, and the `SkillScanner` automatically registers it as an action. The `SkillWatcher` watches for file changes and hot-reloads skills without restarting the DCC.
+
+## Key Concepts
+
+| Concept | Description |
+|---------|-------------|
+| **Action** | A named callable registered with the `ActionAdapter`. Has description, category, and tags. |
+| **Skill** | A zero-code action defined by a `SKILL.md` file. Executed via `run.py` in the same directory. |
+| **Transport** | The protocol used to communicate between the MCP server and the DCC. |
+| **Adapter** | A `DCCAdapter` wraps a `BaseDCCClient` to provide a DCC-specific Python API. |
+| **Service** | A `DCCRPyCService` or `ApplicationRPyCService` runs inside the DCC and handles RPC calls. |
+| **Discovery** | Mechanisms for MCP clients to find running DCC servers (ZeroConf or file-based). |
+
+## Version 2.0.0 Changes
+
+v2.0.0 is the current unreleased version with significant breaking changes:
+
+- **dcc-mcp-core ≥ 0.12.0 required** — fully rewritten from Python/Pydantic to Rust/PyO3.
+- `ActionResultModel.model_dump()` → `ActionResultModel.to_dict()`
+- `ActionRegistry` + `ActionDispatcher` replace old `actions.base` / `actions.manager` modules.
+- New **Rust-native IPC transport** (`IpcClientTransport`, `IpcServerTransport`).
+- New **Skills system** (`SkillManager`, `SkillScanner`, `SkillWatcher`).
+- Package renamed from `dcc-mcp-rpyc` → `dcc-mcp-ipc`.
+
+See the full [CHANGELOG](https://github.com/loonghao/dcc-mcp-ipc/blob/main/CHANGELOG.md) for details.
+
+## Next Steps
+
+- [Installation](./installation) — Install the package and its dependencies.
+- [Quick Start](./quickstart) — Server + client in 5 minutes.
+- [Architecture](./architecture) — Deep dive into the component design.

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -1,0 +1,144 @@
+# Quick Start
+
+This guide shows you how to set up a DCC server inside a DCC application and connect to it from an MCP client.
+
+## 1. Server-side: Inside your DCC application
+
+Create and start an RPyC server inside your DCC (e.g., Maya):
+
+```python
+from dcc_mcp_ipc.server import create_dcc_server, DCCRPyCService
+
+
+class MayaService(DCCRPyCService):
+    def get_scene_info(self):
+        """Return information about the current scene."""
+        return {
+            "name": "my_scene.ma",
+            "objects": 42,
+            "cameras": 2,
+        }
+
+    def exposed_execute_cmd(self, cmd_name, *args, **kwargs):
+        """Execute a Maya MEL or Python command."""
+        import maya.cmds as cmds
+        return getattr(cmds, cmd_name)(*args, **kwargs)
+
+
+# Create and start the server
+server = create_dcc_server(
+    dcc_name="maya",
+    service_class=MayaService,
+    port=18812,  # omit for automatic port selection
+)
+server.start(threaded=True)  # threaded=True avoids blocking Maya's main thread
+print("Maya IPC server started")
+```
+
+## 2. Client-side: From your MCP server
+
+Connect to the DCC from the MCP server process:
+
+```python
+from dcc_mcp_ipc.client import BaseDCCClient
+
+client = BaseDCCClient("maya", host="localhost", port=18812)
+client.connect()
+
+scene = client.call("get_scene_info")
+print(scene)  # {"name": "my_scene.ma", "objects": 42, "cameras": 2}
+
+client.disconnect()
+```
+
+## 3. Using the Action System
+
+For a higher-level approach with MCP tool semantics:
+
+```python
+from dcc_mcp_ipc.action_adapter import get_action_adapter
+
+adapter = get_action_adapter("maya")
+
+
+def create_sphere(radius: float = 1.0, name: str = "sphere1") -> dict:
+    """Create a sphere in Maya."""
+    import maya.cmds as cmds
+    cmds.polySphere(r=radius, name=name)
+    return {"success": True, "message": f"Created sphere '{name}' with radius {radius}"}
+
+
+adapter.register_action(
+    "create_sphere",
+    create_sphere,
+    description="Create a sphere primitive in Maya",
+    category="modeling",
+    tags=["primitive", "mesh"],
+)
+
+# Dispatch the action (parameters are JSON-serialised)
+result = adapter.call_action("create_sphere", radius=2.0, name="mySphere")
+print(result.success)  # True
+print(result.message)  # "Created sphere 'mySphere' with radius 2.0"
+print(result.to_dict())
+```
+
+## 4. Zero-code with Skills
+
+The simplest approach — no Python code required:
+
+```
+my_skills/
+  create_sphere/
+    SKILL.md
+    run.py
+```
+
+**`SKILL.md`:**
+```markdown
+---
+name: create_sphere
+description: Create a sphere primitive in Maya
+category: modeling
+tags:
+  - primitive
+  - mesh
+parameters:
+  radius:
+    type: float
+    default: 1.0
+    description: Sphere radius
+  name:
+    type: string
+    default: sphere1
+    description: Object name
+---
+```
+
+**`run.py`:**
+```python
+import maya.cmds as cmds
+
+# Parameters are injected from SKILL.md schema
+cmds.polySphere(r=radius, name=name)
+result = {"success": True, "name": name}
+```
+
+```python
+from dcc_mcp_ipc.skills import SkillManager
+from dcc_mcp_ipc.action_adapter import get_action_adapter
+
+adapter = get_action_adapter("maya")
+mgr = SkillManager(adapter=adapter, dcc_name="maya")
+mgr.load_paths(["./my_skills"])
+mgr.start_watching()  # Enable hot-reload
+
+result = adapter.call_action("create_sphere", radius=3.0, name="bigSphere")
+```
+
+## Next Steps
+
+- [Architecture](./architecture) — understand the component design
+- [Action System](./action-system) — deep dive into action registration and dispatch
+- [Skills System](./skills) — zero-code tool registration
+- [Transport Layer](./transports) — RPyC, HTTP, WebSocket, and IPC transports

--- a/docs/guide/skills.md
+++ b/docs/guide/skills.md
@@ -1,0 +1,127 @@
+# Skills System
+
+The Skills System enables **zero-code MCP tool registration**. Instead of writing Python boilerplate to register an action, you drop a `SKILL.md` file into a directory and the `SkillManager` auto-registers it.
+
+## Directory Structure
+
+```
+my_skills/
+├── create_sphere/
+│   ├── SKILL.md          # Skill definition (frontmatter)
+│   └── run.py            # Executed when the skill is invoked
+├── render_scene/
+│   ├── SKILL.md
+│   └── run.py
+└── export_fbx/
+    ├── SKILL.md
+    └── run.py
+```
+
+## SKILL.md Format
+
+```markdown
+---
+name: create_sphere
+description: Create a sphere primitive at the specified position
+category: modeling
+tags:
+  - primitive
+  - mesh
+  - geometry
+parameters:
+  radius:
+    type: float
+    default: 1.0
+    description: Sphere radius in scene units
+  name:
+    type: string
+    default: sphere1
+    description: Name for the new object
+  position:
+    type: list
+    default: [0, 0, 0]
+    description: World-space position [x, y, z]
+---
+
+## Create Sphere
+
+Creates a polygonal sphere at the given position.
+```
+
+## run.py
+
+The `run.py` script is executed with the skill's parameters injected into its local scope:
+
+```python
+# Parameters from SKILL.md are available as local variables:
+# radius, name, position
+
+import maya.cmds as cmds
+
+cmds.polySphere(r=radius, name=name)
+cmds.move(*position, name)
+
+result = {
+    "success": True,
+    "name": name,
+    "position": position,
+}
+# `result` is automatically captured and returned
+```
+
+## Using SkillManager
+
+```python
+from dcc_mcp_ipc.skills import SkillManager
+from dcc_mcp_ipc.action_adapter import get_action_adapter
+
+adapter = get_action_adapter("maya")
+mgr = SkillManager(adapter=adapter, dcc_name="maya")
+
+# Register all skills from one or more directories
+mgr.load_paths([
+    "./my_skills",
+    "/pipeline/shared_skills",
+])
+
+# Enable hot-reload (watches for SKILL.md changes)
+mgr.start_watching()
+
+# Skills are now callable via the action adapter
+result = adapter.call_action("create_sphere", radius=2.0, name="bigSphere")
+print(result.success)
+```
+
+## Hot-reload
+
+When `start_watching()` is called, a `SkillWatcher` monitors the loaded paths for file system events:
+
+- **Add / modify** `SKILL.md` → skill is re-registered
+- **Delete** `SKILL.md` → skill is unregistered
+- Changes take effect without restarting the DCC application
+
+To stop watching:
+
+```python
+mgr.stop_watching()
+```
+
+## Environment Variable Configuration
+
+You can configure skill paths via an environment variable instead of hardcoding:
+
+```bash
+export DCC_MCP_SKILL_PATHS=/pipeline/skills:/home/user/my_skills
+```
+
+```python
+mgr = SkillManager(adapter=adapter, dcc_name="maya")
+mgr.load_from_env()  # reads DCC_MCP_SKILL_PATHS
+```
+
+## Listing Loaded Skills
+
+```python
+for skill in mgr.list_skills():
+    print(skill.name, skill.path)
+```

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -1,0 +1,123 @@
+# Testing
+
+DCC-MCP-IPC provides `MockDCCService` so you can test your MCP integration without launching an actual DCC application.
+
+## MockDCCService
+
+`MockDCCService` is a pre-built RPyC service that simulates a DCC application:
+
+```python
+import threading
+import rpyc
+from rpyc.utils.server import ThreadedServer
+from dcc_mcp_ipc.testing.mock_services import MockDCCService
+from dcc_mcp_ipc.client import BaseDCCClient
+
+# Start mock server
+server = ThreadedServer(
+    MockDCCService,
+    port=18812,
+    protocol_config={"allow_public_attrs": True},
+)
+thread = threading.Thread(target=server.start, daemon=True)
+thread.start()
+
+# Connect a real client to the mock
+client = BaseDCCClient("mock_dcc", host="localhost", port=18812)
+client.connect()
+
+info = client.get_dcc_info()
+print(info)  # {"name": "mock_dcc", "version": "1.0.0", ...}
+
+client.disconnect()
+server.close()
+```
+
+## Writing Tests
+
+```python
+import pytest
+import threading
+import rpyc
+from rpyc.utils.server import ThreadedServer
+from dcc_mcp_ipc.testing.mock_services import MockDCCService
+from dcc_mcp_ipc.client import BaseDCCClient
+
+
+@pytest.fixture
+def mock_server():
+    server = ThreadedServer(
+        MockDCCService,
+        port=0,  # random available port
+        protocol_config={"allow_public_attrs": True},
+    )
+    thread = threading.Thread(target=server.start, daemon=True)
+    thread.start()
+    yield server
+    server.close()
+
+
+def test_get_dcc_info(mock_server):
+    client = BaseDCCClient("mock_dcc", host="localhost", port=mock_server.port)
+    client.connect()
+    info = client.get_dcc_info()
+    assert info["name"] == "mock_dcc"
+    client.disconnect()
+```
+
+## Custom Mock Services
+
+Extend `MockDCCService` to add DCC-specific mock behaviour:
+
+```python
+import rpyc
+from dcc_mcp_ipc.testing.mock_services import MockDCCService
+
+
+class MockMayaService(MockDCCService):
+    def exposed_get_scene_info(self, conn=None):
+        return {
+            "name": "test_scene.ma",
+            "objects": ["pSphere1", "pCube1"],
+            "cameras": ["persp", "front"],
+        }
+
+    def exposed_create_sphere(self, radius=1.0, name="sphere1", conn=None):
+        return {
+            "success": True,
+            "name": name,
+            "radius": radius,
+        }
+```
+
+## Testing Action Adapters
+
+```python
+from dcc_mcp_ipc.action_adapter import get_action_adapter
+
+
+def test_action_registration():
+    adapter = get_action_adapter("test_dcc")
+
+    def my_action(value: int = 0) -> dict:
+        return {"result": value * 2}
+
+    adapter.register_action(
+        "double",
+        my_action,
+        description="Double a value",
+        category="math",
+    )
+
+    result = adapter.call_action("double", value=5)
+    assert result.success
+    assert result.context["result"] == 10
+```
+
+## Running the Test Suite
+
+```bash
+nox -s pytest
+```
+
+The test suite has 68 test files organized to mirror the source layout.

--- a/docs/guide/transports.md
+++ b/docs/guide/transports.md
@@ -1,0 +1,114 @@
+# Transport Layer
+
+DCC-MCP-IPC supports multiple transport protocols. The `TransportFactory` selects the right transport from a protocol string.
+
+## Available Transports
+
+| Protocol | Class | Use Case |
+|----------|-------|----------|
+| `rpyc` | `RpycTransport` | DCCs with embedded Python (Maya, Houdini, Blender, 3ds Max, Nuke) |
+| `ipc` | `IpcClientTransport` / `IpcServerTransport` | Rust-native framed channel; lowest latency |
+| `http` | `HttpTransport` | REST-based DCCs (Unreal Engine, Unity) |
+| `websocket` | `WebSocketTransport` | WebSocket-capable services |
+
+## RPyC Transport
+
+The default transport for Python-embedded DCCs.
+
+```python
+from dcc_mcp_ipc.server import create_dcc_server, DCCRPyCService
+from dcc_mcp_ipc.client import BaseDCCClient
+
+# Server side
+server = create_dcc_server(dcc_name="maya", service_class=MayaService, port=18812)
+server.start(threaded=True)
+
+# Client side
+client = BaseDCCClient("maya", host="localhost", port=18812)
+client.connect()
+result = client.call("get_scene_info")
+client.disconnect()
+```
+
+## Rust-native IPC Transport
+
+Zero-copy, low-latency messaging via the Rust `IpcListener` / `FramedChannel` / `connect_ipc` API. Ideal for high-frequency calls or large data payloads.
+
+```python
+import os
+from dcc_mcp_core import TransportAddress
+from dcc_mcp_ipc.transport.ipc_transport import (
+    IpcClientTransport,
+    IpcServerTransport,
+    IpcTransportConfig,
+)
+
+# Server side (inside DCC plugin / Rust process)
+def handle_channel(channel):
+    msg = channel.recv()
+    # process and respond
+    channel.send({"result": "ok"})
+
+addr = TransportAddress.default_local("maya", os.getpid())
+server = IpcServerTransport(addr, handler=handle_channel)
+bound_addr = server.start()
+print(f"IPC server listening at: {bound_addr}")
+
+# Client side
+config = IpcTransportConfig(host="localhost", port=19000)
+transport = IpcClientTransport(config)
+transport.connect()
+result = transport.execute("get_scene_info")
+transport.disconnect()
+```
+
+## HTTP Transport
+
+For DCCs that expose a REST API (e.g., Unreal Engine's Remote Control API, Unity's Editor API):
+
+```python
+from dcc_mcp_ipc.transport.http import HttpTransport
+
+transport = HttpTransport(host="localhost", port=30010)
+transport.connect()
+result = transport.execute("get_scene_info")
+transport.disconnect()
+```
+
+## WebSocket Transport
+
+```python
+from dcc_mcp_ipc.transport.websocket import WebSocketTransport
+
+transport = WebSocketTransport(host="localhost", port=8765)
+transport.connect()
+result = transport.execute("list_actors")
+transport.disconnect()
+```
+
+## Transport Factory
+
+```python
+from dcc_mcp_ipc.transport import TransportFactory
+
+# protocol → transport instance
+transport = TransportFactory.create("rpyc", host="localhost", port=18812)
+transport = TransportFactory.create("ipc", host="localhost", port=19000)
+transport = TransportFactory.create("http", host="localhost", port=30010)
+```
+
+## Choosing a Transport
+
+```
+Is the DCC's scripting API accessible via Python in the same process?
+    → RPyC transport (most DCCs)
+
+Does the DCC expose a REST API?
+    → HTTP transport (Unreal Engine Remote Control, Unity Editor API)
+
+Do you need minimum latency with a Rust-based plugin?
+    → IPC transport
+
+Does the DCC use WebSockets for its API?
+    → WebSocket transport
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,43 @@
+---
+layout: home
+
+hero:
+  name: DCC-MCP-IPC
+  text: Multi-protocol IPC for DCC + MCP
+  tagline: Connect AI assistants to Maya, Houdini, Blender, Unreal Engine and more via Model Context Protocol
+  image:
+    src: /logo.svg
+    alt: DCC-MCP-IPC
+  actions:
+    - theme: brand
+      text: Get Started
+      link: /guide/introduction
+    - theme: alt
+      text: View on GitHub
+      link: https://github.com/loonghao/dcc-mcp-ipc
+
+features:
+  - icon: 🔌
+    title: Protocol-agnostic
+    details: RPyC for embedded-Python DCCs (Maya/Houdini/Blender), HTTP for Unreal/Unity, WebSocket, and Rust-native IPC for maximum throughput.
+
+  - icon: ⚡
+    title: Zero-code Skills
+    details: Drop a SKILL.md file into a directory — SkillManager auto-registers it as an MCP tool. Hot-reload on file changes, no DCC restart needed.
+
+  - icon: 🦀
+    title: Rust-powered Core
+    details: Action dispatch, validation, and telemetry handled by dcc-mcp-core (Rust/PyO3). Python layer focuses on DCC-specific glue code.
+
+  - icon: 🔍
+    title: Service Discovery
+    details: ZeroConf (mDNS) + file-based fallback for automatic DCC server detection with no manual configuration.
+
+  - icon: 🔄
+    title: Connection Pooling
+    details: ConnectionPool with auto-discovery for efficient client-side connection reuse and management.
+
+  - icon: 🧪
+    title: Testing-first
+    details: MockDCCService lets you test your MCP integration without launching an actual DCC application.
+---

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,0 +1,2513 @@
+{
+  "name": "dcc-mcp-ipc-docs",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "dcc-mcp-ipc-docs",
+      "version": "1.0.0",
+      "devDependencies": {
+        "vitepress": "^1.6.4"
+      }
+    },
+    "node_modules/@algolia/abtesting": {
+      "version": "1.16.1",
+      "resolved": "https://mirrors.tencent.com/npm/@algolia/abtesting/-/abtesting-1.16.1.tgz",
+      "integrity": "sha512-Xxk4l00pYI+jE0PNw8y0MvsQWh5278WRtZQav8/BMMi3HKi2xmeuqe11WJ3y8/6nuBHdv39w76OpJb09TMfAVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.50.1",
+        "@algolia/requester-browser-xhr": "5.50.1",
+        "@algolia/requester-fetch": "5.50.1",
+        "@algolia/requester-node-http": "5.50.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/autocomplete-core": {
+      "version": "1.17.7",
+      "resolved": "https://mirrors.tencent.com/npm/@algolia/autocomplete-core/-/autocomplete-core-1.17.7.tgz",
+      "integrity": "sha512-BjiPOW6ks90UKl7TwMv7oNQMnzU+t/wk9mgIDi6b1tXpUek7MW0lbNOUHpvam9pe3lVCf4xPFT+lK7s+e+fs7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-plugin-algolia-insights": "1.17.7",
+        "@algolia/autocomplete-shared": "1.17.7"
+      }
+    },
+    "node_modules/@algolia/autocomplete-plugin-algolia-insights": {
+      "version": "1.17.7",
+      "resolved": "https://mirrors.tencent.com/npm/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.17.7.tgz",
+      "integrity": "sha512-Jca5Ude6yUOuyzjnz57og7Et3aXjbwCSDf/8onLHSQgw1qW3ALl9mrMWaXb5FmPVkV3EtkD2F/+NkT6VHyPu9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.17.7"
+      },
+      "peerDependencies": {
+        "search-insights": ">= 1 < 3"
+      }
+    },
+    "node_modules/@algolia/autocomplete-preset-algolia": {
+      "version": "1.17.7",
+      "resolved": "https://mirrors.tencent.com/npm/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.17.7.tgz",
+      "integrity": "sha512-ggOQ950+nwbWROq2MOCIL71RE0DdQZsceqrg32UqnhDz8FlO9rL8ONHNsI2R1MH0tkgVIDKI/D0sMiUchsFdWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.17.7"
+      },
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/autocomplete-shared": {
+      "version": "1.17.7",
+      "resolved": "https://mirrors.tencent.com/npm/@algolia/autocomplete-shared/-/autocomplete-shared-1.17.7.tgz",
+      "integrity": "sha512-o/1Vurr42U/qskRSuhBH+VKxMvkkUVTLU6WZQr+L5lGZZLYWyhdzWjW0iGXY7EkwRTjBqvN2EsR81yCTGV/kmg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/client-abtesting": {
+      "version": "5.50.1",
+      "resolved": "https://mirrors.tencent.com/npm/@algolia/client-abtesting/-/client-abtesting-5.50.1.tgz",
+      "integrity": "sha512-4peZlPXMwTOey9q1rQKMdCnwZb/E95/1e+7KujXpLLSh0FawJzg//U2NM+r4AiJy4+naT2MTBhj0K30yshnVTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.50.1",
+        "@algolia/requester-browser-xhr": "5.50.1",
+        "@algolia/requester-fetch": "5.50.1",
+        "@algolia/requester-node-http": "5.50.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-analytics": {
+      "version": "5.50.1",
+      "resolved": "https://mirrors.tencent.com/npm/@algolia/client-analytics/-/client-analytics-5.50.1.tgz",
+      "integrity": "sha512-i+aWHHG8NZvGFHtPeMZkxL2Loc6Fm7iaRo15lYSMx8gFL+at9vgdWxhka7mD1fqxkrxXsQstUBCIsSY8FvkEOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.50.1",
+        "@algolia/requester-browser-xhr": "5.50.1",
+        "@algolia/requester-fetch": "5.50.1",
+        "@algolia/requester-node-http": "5.50.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-common": {
+      "version": "5.50.1",
+      "resolved": "https://mirrors.tencent.com/npm/@algolia/client-common/-/client-common-5.50.1.tgz",
+      "integrity": "sha512-Hw52Fwapyk/7hMSV/fI4+s3H9MGZEUcRh4VphyXLAk2oLYdndVUkc6KBi0zwHSzwPAr+ZBwFPe2x6naUt9mZGw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-insights": {
+      "version": "5.50.1",
+      "resolved": "https://mirrors.tencent.com/npm/@algolia/client-insights/-/client-insights-5.50.1.tgz",
+      "integrity": "sha512-Bn/wtwhJ7p1OD/6pY+Zzn+zlu2N/SJnH46md/PAbvqIzmjVuwjNwD4y0vV5Ov8naeukXdd7UU9v550+v8+mtlg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.50.1",
+        "@algolia/requester-browser-xhr": "5.50.1",
+        "@algolia/requester-fetch": "5.50.1",
+        "@algolia/requester-node-http": "5.50.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-personalization": {
+      "version": "5.50.1",
+      "resolved": "https://mirrors.tencent.com/npm/@algolia/client-personalization/-/client-personalization-5.50.1.tgz",
+      "integrity": "sha512-0V4Tu0RWR8YxkgI9EPVOZHGE4K5pEIhkLNN0CTkP/rnPsqaaSQpNMYW3/mGWdiKOWbX0iVmwLB9QESk3H0jS5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.50.1",
+        "@algolia/requester-browser-xhr": "5.50.1",
+        "@algolia/requester-fetch": "5.50.1",
+        "@algolia/requester-node-http": "5.50.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-query-suggestions": {
+      "version": "5.50.1",
+      "resolved": "https://mirrors.tencent.com/npm/@algolia/client-query-suggestions/-/client-query-suggestions-5.50.1.tgz",
+      "integrity": "sha512-jofcWNYMXJDDr87Z2eivlWY6o71Zn7F7aOvQCXSDAo9QTlyf7BhXEsZymLUvF0O1yU9Q9wvrjAWn8uVHYnAvgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.50.1",
+        "@algolia/requester-browser-xhr": "5.50.1",
+        "@algolia/requester-fetch": "5.50.1",
+        "@algolia/requester-node-http": "5.50.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-search": {
+      "version": "5.50.1",
+      "resolved": "https://mirrors.tencent.com/npm/@algolia/client-search/-/client-search-5.50.1.tgz",
+      "integrity": "sha512-OteRb8WubcmEvU0YlMJwCXs3Q6xrdkb0v50/qZBJP1TF0CvujFZQM++9BjEkTER/Jr9wbPHvjSFKnbMta0b4dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.50.1",
+        "@algolia/requester-browser-xhr": "5.50.1",
+        "@algolia/requester-fetch": "5.50.1",
+        "@algolia/requester-node-http": "5.50.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/ingestion": {
+      "version": "1.50.1",
+      "resolved": "https://mirrors.tencent.com/npm/@algolia/ingestion/-/ingestion-1.50.1.tgz",
+      "integrity": "sha512-0GmfSgDQK6oiIVXnJvGxtNFOfosBspRTR7csCOYCTL1P8QtxX2vDCIKwTM7xdSAEbJaZ43QlWg25q0Qdsndz8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.50.1",
+        "@algolia/requester-browser-xhr": "5.50.1",
+        "@algolia/requester-fetch": "5.50.1",
+        "@algolia/requester-node-http": "5.50.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/monitoring": {
+      "version": "1.50.1",
+      "resolved": "https://mirrors.tencent.com/npm/@algolia/monitoring/-/monitoring-1.50.1.tgz",
+      "integrity": "sha512-ySuigKEe4YjYV3si8NVk9BHQpFj/1B+ON7DhhvTvbrZJseHQQloxzq0yHwKmznSdlO6C956fx4pcfOKkZClsyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.50.1",
+        "@algolia/requester-browser-xhr": "5.50.1",
+        "@algolia/requester-fetch": "5.50.1",
+        "@algolia/requester-node-http": "5.50.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/recommend": {
+      "version": "5.50.1",
+      "resolved": "https://mirrors.tencent.com/npm/@algolia/recommend/-/recommend-5.50.1.tgz",
+      "integrity": "sha512-Cp8T/B0gVmjFlzzp6eP47hwKh5FGyeqQp1N48/ANDdvdiQkPqLyFHQVDwLBH0LddfIPQE+yqmZIgmKc82haF4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.50.1",
+        "@algolia/requester-browser-xhr": "5.50.1",
+        "@algolia/requester-fetch": "5.50.1",
+        "@algolia/requester-node-http": "5.50.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-browser-xhr": {
+      "version": "5.50.1",
+      "resolved": "https://mirrors.tencent.com/npm/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.50.1.tgz",
+      "integrity": "sha512-XKdGGLikfrlK66ZSXh/vWcXZZ8Vg3byDFbJD8pwEvN1FoBRGxhxya476IY2ohoTymLa4qB5LBRlIa+2TLHx3Uw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.50.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-fetch": {
+      "version": "5.50.1",
+      "resolved": "https://mirrors.tencent.com/npm/@algolia/requester-fetch/-/requester-fetch-5.50.1.tgz",
+      "integrity": "sha512-mBAU6WyVsDwhHyGM+nodt1/oebHxgvuLlOAoMGbj/1i6LygDHZWDgL1t5JEs37x9Aywv7ZGhqbM1GsfZ54sU6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.50.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-node-http": {
+      "version": "5.50.1",
+      "resolved": "https://mirrors.tencent.com/npm/@algolia/requester-node-http/-/requester-node-http-5.50.1.tgz",
+      "integrity": "sha512-qmo1LXrNKLHvJE6mdQbLnsZAoZvj7VyF2ft4xmbSGWI2WWm87fx/CjUX4kEExt4y0a6T6nEts6ofpUfH5TEE1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.50.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://mirrors.tencent.com/npm/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://mirrors.tencent.com/npm/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://mirrors.tencent.com/npm/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://mirrors.tencent.com/npm/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@docsearch/css": {
+      "version": "3.8.2",
+      "resolved": "https://mirrors.tencent.com/npm/@docsearch/css/-/css-3.8.2.tgz",
+      "integrity": "sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@docsearch/js": {
+      "version": "3.8.2",
+      "resolved": "https://mirrors.tencent.com/npm/@docsearch/js/-/js-3.8.2.tgz",
+      "integrity": "sha512-Q5wY66qHn0SwA7Taa0aDbHiJvaFJLOJyHmooQ7y8hlwwQLQ/5WwCcoX0g7ii04Qi2DJlHsd0XXzJ8Ypw9+9YmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@docsearch/react": "3.8.2",
+        "preact": "^10.0.0"
+      }
+    },
+    "node_modules/@docsearch/react": {
+      "version": "3.8.2",
+      "resolved": "https://mirrors.tencent.com/npm/@docsearch/react/-/react-3.8.2.tgz",
+      "integrity": "sha512-xCRrJQlTt8N9GU0DG4ptwHRkfnSnD/YpdeaXe02iKfqs97TkZJv60yE+1eq/tjPcVnTW8dP5qLP7itifFVV5eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-core": "1.17.7",
+        "@algolia/autocomplete-preset-algolia": "1.17.7",
+        "@docsearch/css": "3.8.2",
+        "algoliasearch": "^5.14.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">= 16.8.0 < 19.0.0",
+        "react": ">= 16.8.0 < 19.0.0",
+        "react-dom": ">= 16.8.0 < 19.0.0",
+        "search-insights": ">= 1 < 3"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "search-insights": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://mirrors.tencent.com/npm/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://mirrors.tencent.com/npm/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://mirrors.tencent.com/npm/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://mirrors.tencent.com/npm/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://mirrors.tencent.com/npm/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://mirrors.tencent.com/npm/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://mirrors.tencent.com/npm/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://mirrors.tencent.com/npm/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://mirrors.tencent.com/npm/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://mirrors.tencent.com/npm/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://mirrors.tencent.com/npm/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://mirrors.tencent.com/npm/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://mirrors.tencent.com/npm/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://mirrors.tencent.com/npm/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://mirrors.tencent.com/npm/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://mirrors.tencent.com/npm/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://mirrors.tencent.com/npm/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://mirrors.tencent.com/npm/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://mirrors.tencent.com/npm/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://mirrors.tencent.com/npm/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://mirrors.tencent.com/npm/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://mirrors.tencent.com/npm/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://mirrors.tencent.com/npm/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@iconify-json/simple-icons": {
+      "version": "1.2.77",
+      "resolved": "https://mirrors.tencent.com/npm/@iconify-json/simple-icons/-/simple-icons-1.2.77.tgz",
+      "integrity": "sha512-oaENvo6C3BkAEWMlcQA3XemxU9v2SFOTlApSUCODAkIu1haeLCjzrmH3HgmGqjRnJjM+LevO8sA+MgdMHBFBDA==",
+      "dev": true,
+      "license": "CC0-1.0",
+      "dependencies": {
+        "@iconify/types": "*"
+      }
+    },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://mirrors.tencent.com/npm/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://mirrors.tencent.com/npm/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.1",
+      "resolved": "https://mirrors.tencent.com/npm/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
+      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://mirrors.tencent.com/npm/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
+      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://mirrors.tencent.com/npm/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
+      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.1",
+      "resolved": "https://mirrors.tencent.com/npm/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
+      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://mirrors.tencent.com/npm/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
+      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://mirrors.tencent.com/npm/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
+      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.1",
+      "resolved": "https://mirrors.tencent.com/npm/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
+      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.1",
+      "resolved": "https://mirrors.tencent.com/npm/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
+      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://mirrors.tencent.com/npm/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
+      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://mirrors.tencent.com/npm/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
+      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://mirrors.tencent.com/npm/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
+      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://mirrors.tencent.com/npm/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
+      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://mirrors.tencent.com/npm/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
+      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://mirrors.tencent.com/npm/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
+      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://mirrors.tencent.com/npm/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
+      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://mirrors.tencent.com/npm/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
+      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://mirrors.tencent.com/npm/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
+      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://mirrors.tencent.com/npm/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://mirrors.tencent.com/npm/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
+      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://mirrors.tencent.com/npm/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
+      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://mirrors.tencent.com/npm/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
+      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://mirrors.tencent.com/npm/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
+      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://mirrors.tencent.com/npm/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
+      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://mirrors.tencent.com/npm/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://mirrors.tencent.com/npm/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
+      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@shikijs/core": {
+      "version": "2.5.0",
+      "resolved": "https://mirrors.tencent.com/npm/@shikijs/core/-/core-2.5.0.tgz",
+      "integrity": "sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/engine-javascript": "2.5.0",
+        "@shikijs/engine-oniguruma": "2.5.0",
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.4"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "2.5.0",
+      "resolved": "https://mirrors.tencent.com/npm/@shikijs/engine-javascript/-/engine-javascript-2.5.0.tgz",
+      "integrity": "sha512-VjnOpnQf8WuCEZtNUdjjwGUbtAVKuZkVQ/5cHy/tojVVRIRtlWMYVjyWhxOmIq05AlSOv72z7hRNRGVBgQOl0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^3.1.0"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "2.5.0",
+      "resolved": "https://mirrors.tencent.com/npm/@shikijs/engine-oniguruma/-/engine-oniguruma-2.5.0.tgz",
+      "integrity": "sha512-pGd1wRATzbo/uatrCIILlAdFVKdxImWJGQ5rFiB5VZi2ve5xj3Ax9jny8QvkaV93btQEwR/rSz5ERFpC5mKNIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "2.5.0",
+      "resolved": "https://mirrors.tencent.com/npm/@shikijs/langs/-/langs-2.5.0.tgz",
+      "integrity": "sha512-Qfrrt5OsNH5R+5tJ/3uYBBZv3SuGmnRPejV9IlIbFH3HTGLDlkqgHymAlzklVmKBjAaVmkPkyikAV/sQ1wSL+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "2.5.0",
+      "resolved": "https://mirrors.tencent.com/npm/@shikijs/themes/-/themes-2.5.0.tgz",
+      "integrity": "sha512-wGrk+R8tJnO0VMzmUExHR+QdSaPUl/NKs+a4cQQRWyoc3YFbUzuLEi/KWK1hj+8BfHRKm2jNhhJck1dfstJpiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/transformers": {
+      "version": "2.5.0",
+      "resolved": "https://mirrors.tencent.com/npm/@shikijs/transformers/-/transformers-2.5.0.tgz",
+      "integrity": "sha512-SI494W5X60CaUwgi8u4q4m4s3YAFSxln3tzNjOSYqq54wlVgz0/NbbXEb3mdLbqMBztcmS7bVTaEd2w0qMmfeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "2.5.0",
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "2.5.0",
+      "resolved": "https://mirrors.tencent.com/npm/@shikijs/types/-/types-2.5.0.tgz",
+      "integrity": "sha512-ygl5yhxki9ZLNuNpPitBWvcy9fsSKKaRuO4BAlMyagszQidxcpLAr0qiW/q43DtSIDxO6hEbtYLiFZNXO/hdGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://mirrors.tencent.com/npm/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://mirrors.tencent.com/npm/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://mirrors.tencent.com/npm/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://mirrors.tencent.com/npm/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://mirrors.tencent.com/npm/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://mirrors.tencent.com/npm/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://mirrors.tencent.com/npm/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://mirrors.tencent.com/npm/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/web-bluetooth": {
+      "version": "0.0.21",
+      "resolved": "https://mirrors.tencent.com/npm/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
+      "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://mirrors.tencent.com/npm/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@vitejs/plugin-vue": {
+      "version": "5.2.4",
+      "resolved": "https://mirrors.tencent.com/npm/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
+      "integrity": "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0",
+        "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.32",
+      "resolved": "https://mirrors.tencent.com/npm/@vue/compiler-core/-/compiler-core-3.5.32.tgz",
+      "integrity": "sha512-4x74Tbtqnda8s/NSD6e1Dr5p1c8HdMU5RWSjMSUzb8RTcUQqevDCxVAitcLBKT+ie3o0Dl9crc/S/opJM7qBGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.2",
+        "@vue/shared": "3.5.32",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.32",
+      "resolved": "https://mirrors.tencent.com/npm/@vue/compiler-dom/-/compiler-dom-3.5.32.tgz",
+      "integrity": "sha512-ybHAu70NtiEI1fvAUz3oXZqkUYEe5J98GjMDpTGl5iHb0T15wQYLR4wE3h9xfuTNA+Cm2f4czfe8B4s+CCH57Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.32",
+        "@vue/shared": "3.5.32"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.32",
+      "resolved": "https://mirrors.tencent.com/npm/@vue/compiler-sfc/-/compiler-sfc-3.5.32.tgz",
+      "integrity": "sha512-8UYUYo71cP/0YHMO814TRZlPuUUw3oifHuMR7Wp9SNoRSrxRQnhMLNlCeaODNn6kNTJsjFoQ/kqIj4qGvya4Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.2",
+        "@vue/compiler-core": "3.5.32",
+        "@vue/compiler-dom": "3.5.32",
+        "@vue/compiler-ssr": "3.5.32",
+        "@vue/shared": "3.5.32",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.8",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.32",
+      "resolved": "https://mirrors.tencent.com/npm/@vue/compiler-ssr/-/compiler-ssr-3.5.32.tgz",
+      "integrity": "sha512-Gp4gTs22T3DgRotZ8aA/6m2jMR+GMztvBXUBEUOYOcST+giyGWJ4WvFd7QLHBkzTxkfOt8IELKNdpzITLbA2rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.32",
+        "@vue/shared": "3.5.32"
+      }
+    },
+    "node_modules/@vue/devtools-api": {
+      "version": "7.7.9",
+      "resolved": "https://mirrors.tencent.com/npm/@vue/devtools-api/-/devtools-api-7.7.9.tgz",
+      "integrity": "sha512-kIE8wvwlcZ6TJTbNeU2HQNtaxLx3a84aotTITUuL/4bzfPxzajGBOoqjMhwZJ8L9qFYDU/lAYMEEm11dnZOD6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-kit": "^7.7.9"
+      }
+    },
+    "node_modules/@vue/devtools-kit": {
+      "version": "7.7.9",
+      "resolved": "https://mirrors.tencent.com/npm/@vue/devtools-kit/-/devtools-kit-7.7.9.tgz",
+      "integrity": "sha512-PyQ6odHSgiDVd4hnTP+aDk2X4gl2HmLDfiyEnn3/oV+ckFDuswRs4IbBT7vacMuGdwY/XemxBoh302ctbsptuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-shared": "^7.7.9",
+        "birpc": "^2.3.0",
+        "hookable": "^5.5.3",
+        "mitt": "^3.0.1",
+        "perfect-debounce": "^1.0.0",
+        "speakingurl": "^14.0.1",
+        "superjson": "^2.2.2"
+      }
+    },
+    "node_modules/@vue/devtools-shared": {
+      "version": "7.7.9",
+      "resolved": "https://mirrors.tencent.com/npm/@vue/devtools-shared/-/devtools-shared-7.7.9.tgz",
+      "integrity": "sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rfdc": "^1.4.1"
+      }
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.32",
+      "resolved": "https://mirrors.tencent.com/npm/@vue/reactivity/-/reactivity-3.5.32.tgz",
+      "integrity": "sha512-/ORasxSGvZ6MN5gc+uE364SxFdJ0+WqVG0CENXaGW58TOCdrAW76WWaplDtECeS1qphvtBZtR+3/o1g1zL4xPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.5.32"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.32",
+      "resolved": "https://mirrors.tencent.com/npm/@vue/runtime-core/-/runtime-core-3.5.32.tgz",
+      "integrity": "sha512-pDrXCejn4UpFDFmMd27AcJEbHaLemaE5o4pbb7sLk79SRIhc6/t34BQA7SGNgYtbMnvbF/HHOftYBgFJtUoJUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.32",
+        "@vue/shared": "3.5.32"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.32",
+      "resolved": "https://mirrors.tencent.com/npm/@vue/runtime-dom/-/runtime-dom-3.5.32.tgz",
+      "integrity": "sha512-1CDVv7tv/IV13V8Nip1k/aaObVbWqRlVCVezTwx3K07p7Vxossp5JU1dcPNhJk3w347gonIUT9jQOGutyJrSVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.32",
+        "@vue/runtime-core": "3.5.32",
+        "@vue/shared": "3.5.32",
+        "csstype": "^3.2.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.32",
+      "resolved": "https://mirrors.tencent.com/npm/@vue/server-renderer/-/server-renderer-3.5.32.tgz",
+      "integrity": "sha512-IOjm2+JQwRFS7W28HNuJeXQle9KdZbODFY7hFGVtnnghF51ta20EWAZJHX+zLGtsHhaU6uC9BGPV52KVpYryMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.32",
+        "@vue/shared": "3.5.32"
+      },
+      "peerDependencies": {
+        "vue": "3.5.32"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.32",
+      "resolved": "https://mirrors.tencent.com/npm/@vue/shared/-/shared-3.5.32.tgz",
+      "integrity": "sha512-ksNyrmRQzWJJ8n3cRDuSF7zNNontuJg1YHnmWRJd2AMu8Ij2bqwiiri2lH5rHtYPZjj4STkNcgcmiQqlOjiYGg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vueuse/core": {
+      "version": "12.8.2",
+      "resolved": "https://mirrors.tencent.com/npm/@vueuse/core/-/core-12.8.2.tgz",
+      "integrity": "sha512-HbvCmZdzAu3VGi/pWYm5Ut+Kd9mn1ZHnn4L5G8kOQTPs/IwIAmJoBrmYk2ckLArgMXZj0AW3n5CAejLUO+PhdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.21",
+        "@vueuse/metadata": "12.8.2",
+        "@vueuse/shared": "12.8.2",
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/integrations": {
+      "version": "12.8.2",
+      "resolved": "https://mirrors.tencent.com/npm/@vueuse/integrations/-/integrations-12.8.2.tgz",
+      "integrity": "sha512-fbGYivgK5uBTRt7p5F3zy6VrETlV9RtZjBqd1/HxGdjdckBgBM4ugP8LHpjolqTj14TXTxSK1ZfgPbHYyGuH7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vueuse/core": "12.8.2",
+        "@vueuse/shared": "12.8.2",
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "async-validator": "^4",
+        "axios": "^1",
+        "change-case": "^5",
+        "drauu": "^0.4",
+        "focus-trap": "^7",
+        "fuse.js": "^7",
+        "idb-keyval": "^6",
+        "jwt-decode": "^4",
+        "nprogress": "^0.2",
+        "qrcode": "^1.5",
+        "sortablejs": "^1",
+        "universal-cookie": "^7"
+      },
+      "peerDependenciesMeta": {
+        "async-validator": {
+          "optional": true
+        },
+        "axios": {
+          "optional": true
+        },
+        "change-case": {
+          "optional": true
+        },
+        "drauu": {
+          "optional": true
+        },
+        "focus-trap": {
+          "optional": true
+        },
+        "fuse.js": {
+          "optional": true
+        },
+        "idb-keyval": {
+          "optional": true
+        },
+        "jwt-decode": {
+          "optional": true
+        },
+        "nprogress": {
+          "optional": true
+        },
+        "qrcode": {
+          "optional": true
+        },
+        "sortablejs": {
+          "optional": true
+        },
+        "universal-cookie": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vueuse/metadata": {
+      "version": "12.8.2",
+      "resolved": "https://mirrors.tencent.com/npm/@vueuse/metadata/-/metadata-12.8.2.tgz",
+      "integrity": "sha512-rAyLGEuoBJ/Il5AmFHiziCPdQzRt88VxR+Y/A/QhJ1EWtWqPBBAxTAFaSkviwEuOEZNtW8pvkPgoCZQ+HxqW1A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/shared": {
+      "version": "12.8.2",
+      "resolved": "https://mirrors.tencent.com/npm/@vueuse/shared/-/shared-12.8.2.tgz",
+      "integrity": "sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/algoliasearch": {
+      "version": "5.50.1",
+      "resolved": "https://mirrors.tencent.com/npm/algoliasearch/-/algoliasearch-5.50.1.tgz",
+      "integrity": "sha512-/bwdue1/8LWELn/DBalGRfuLsXBLXULJo/yOeavJtDu8rBwxIzC6/Rz9Jg19S21VkJvRuZO1k8CZXBMS73mYbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/abtesting": "1.16.1",
+        "@algolia/client-abtesting": "5.50.1",
+        "@algolia/client-analytics": "5.50.1",
+        "@algolia/client-common": "5.50.1",
+        "@algolia/client-insights": "5.50.1",
+        "@algolia/client-personalization": "5.50.1",
+        "@algolia/client-query-suggestions": "5.50.1",
+        "@algolia/client-search": "5.50.1",
+        "@algolia/ingestion": "1.50.1",
+        "@algolia/monitoring": "1.50.1",
+        "@algolia/recommend": "5.50.1",
+        "@algolia/requester-browser-xhr": "5.50.1",
+        "@algolia/requester-fetch": "5.50.1",
+        "@algolia/requester-node-http": "5.50.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/birpc": {
+      "version": "2.9.0",
+      "resolved": "https://mirrors.tencent.com/npm/birpc/-/birpc-2.9.0.tgz",
+      "integrity": "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://mirrors.tencent.com/npm/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://mirrors.tencent.com/npm/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://mirrors.tencent.com/npm/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://mirrors.tencent.com/npm/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/copy-anything": {
+      "version": "4.0.5",
+      "resolved": "https://mirrors.tencent.com/npm/copy-anything/-/copy-anything-4.0.5.tgz",
+      "integrity": "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-what": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://mirrors.tencent.com/npm/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://mirrors.tencent.com/npm/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://mirrors.tencent.com/npm/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/emoji-regex-xs": {
+      "version": "1.0.0",
+      "resolved": "https://mirrors.tencent.com/npm/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
+      "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://mirrors.tencent.com/npm/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://mirrors.tencent.com/npm/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://mirrors.tencent.com/npm/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/focus-trap": {
+      "version": "7.8.0",
+      "resolved": "https://mirrors.tencent.com/npm/focus-trap/-/focus-trap-7.8.0.tgz",
+      "integrity": "sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tabbable": "^6.4.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://mirrors.tencent.com/npm/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://mirrors.tencent.com/npm/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://mirrors.tencent.com/npm/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hookable": {
+      "version": "5.5.3",
+      "resolved": "https://mirrors.tencent.com/npm/hookable/-/hookable-5.5.3.tgz",
+      "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://mirrors.tencent.com/npm/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-what": {
+      "version": "5.5.0",
+      "resolved": "https://mirrors.tencent.com/npm/is-what/-/is-what-5.5.0.tgz",
+      "integrity": "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://mirrors.tencent.com/npm/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mark.js": {
+      "version": "8.11.1",
+      "resolved": "https://mirrors.tencent.com/npm/mark.js/-/mark.js-8.11.1.tgz",
+      "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://mirrors.tencent.com/npm/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://mirrors.tencent.com/npm/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://mirrors.tencent.com/npm/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://mirrors.tencent.com/npm/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://mirrors.tencent.com/npm/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://mirrors.tencent.com/npm/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/minisearch": {
+      "version": "7.2.0",
+      "resolved": "https://mirrors.tencent.com/npm/minisearch/-/minisearch-7.2.0.tgz",
+      "integrity": "sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://mirrors.tencent.com/npm/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://mirrors.tencent.com/npm/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "3.1.1",
+      "resolved": "https://mirrors.tencent.com/npm/oniguruma-to-es/-/oniguruma-to-es-3.1.1.tgz",
+      "integrity": "sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex-xs": "^1.0.0",
+        "regex": "^6.0.1",
+        "regex-recursion": "^6.0.2"
+      }
+    },
+    "node_modules/perfect-debounce": {
+      "version": "1.0.0",
+      "resolved": "https://mirrors.tencent.com/npm/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
+      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://mirrors.tencent.com/npm/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.8",
+      "resolved": "https://mirrors.tencent.com/npm/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.29.1",
+      "resolved": "https://mirrors.tencent.com/npm/preact/-/preact-10.29.1.tgz",
+      "integrity": "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://mirrors.tencent.com/npm/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://mirrors.tencent.com/npm/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://mirrors.tencent.com/npm/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://mirrors.tencent.com/npm/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://mirrors.tencent.com/npm/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rollup": {
+      "version": "4.60.1",
+      "resolved": "https://mirrors.tencent.com/npm/rollup/-/rollup-4.60.1.tgz",
+      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.1",
+        "@rollup/rollup-android-arm64": "4.60.1",
+        "@rollup/rollup-darwin-arm64": "4.60.1",
+        "@rollup/rollup-darwin-x64": "4.60.1",
+        "@rollup/rollup-freebsd-arm64": "4.60.1",
+        "@rollup/rollup-freebsd-x64": "4.60.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
+        "@rollup/rollup-linux-arm64-musl": "4.60.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
+        "@rollup/rollup-linux-loong64-musl": "4.60.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-musl": "4.60.1",
+        "@rollup/rollup-openbsd-x64": "4.60.1",
+        "@rollup/rollup-openharmony-arm64": "4.60.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
+        "@rollup/rollup-win32-x64-gnu": "4.60.1",
+        "@rollup/rollup-win32-x64-msvc": "4.60.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/search-insights": {
+      "version": "2.17.3",
+      "resolved": "https://mirrors.tencent.com/npm/search-insights/-/search-insights-2.17.3.tgz",
+      "integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/shiki": {
+      "version": "2.5.0",
+      "resolved": "https://mirrors.tencent.com/npm/shiki/-/shiki-2.5.0.tgz",
+      "integrity": "sha512-mI//trrsaiCIPsja5CNfsyNOqgAZUb6VpJA+340toL42UpzQlXpwRV9nch69X6gaUxrr9kaOOa6e3y3uAkGFxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "2.5.0",
+        "@shikijs/engine-javascript": "2.5.0",
+        "@shikijs/engine-oniguruma": "2.5.0",
+        "@shikijs/langs": "2.5.0",
+        "@shikijs/themes": "2.5.0",
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://mirrors.tencent.com/npm/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://mirrors.tencent.com/npm/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/speakingurl": {
+      "version": "14.0.1",
+      "resolved": "https://mirrors.tencent.com/npm/speakingurl/-/speakingurl-14.0.1.tgz",
+      "integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://mirrors.tencent.com/npm/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/superjson": {
+      "version": "2.2.6",
+      "resolved": "https://mirrors.tencent.com/npm/superjson/-/superjson-2.2.6.tgz",
+      "integrity": "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "copy-anything": "^4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tabbable": {
+      "version": "6.4.0",
+      "resolved": "https://mirrors.tencent.com/npm/tabbable/-/tabbable-6.4.0.tgz",
+      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://mirrors.tencent.com/npm/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://mirrors.tencent.com/npm/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://mirrors.tencent.com/npm/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://mirrors.tencent.com/npm/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://mirrors.tencent.com/npm/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://mirrors.tencent.com/npm/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://mirrors.tencent.com/npm/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://mirrors.tencent.com/npm/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://mirrors.tencent.com/npm/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitepress": {
+      "version": "1.6.4",
+      "resolved": "https://mirrors.tencent.com/npm/vitepress/-/vitepress-1.6.4.tgz",
+      "integrity": "sha512-+2ym1/+0VVrbhNyRoFFesVvBvHAVMZMK0rw60E3X/5349M1GuVdKeazuksqopEdvkKwKGs21Q729jX81/bkBJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@docsearch/css": "3.8.2",
+        "@docsearch/js": "3.8.2",
+        "@iconify-json/simple-icons": "^1.2.21",
+        "@shikijs/core": "^2.1.0",
+        "@shikijs/transformers": "^2.1.0",
+        "@shikijs/types": "^2.1.0",
+        "@types/markdown-it": "^14.1.2",
+        "@vitejs/plugin-vue": "^5.2.1",
+        "@vue/devtools-api": "^7.7.0",
+        "@vue/shared": "^3.5.13",
+        "@vueuse/core": "^12.4.0",
+        "@vueuse/integrations": "^12.4.0",
+        "focus-trap": "^7.6.4",
+        "mark.js": "8.11.1",
+        "minisearch": "^7.1.1",
+        "shiki": "^2.1.0",
+        "vite": "^5.4.14",
+        "vue": "^3.5.13"
+      },
+      "bin": {
+        "vitepress": "bin/vitepress.js"
+      },
+      "peerDependencies": {
+        "markdown-it-mathjax3": "^4",
+        "postcss": "^8"
+      },
+      "peerDependenciesMeta": {
+        "markdown-it-mathjax3": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue": {
+      "version": "3.5.32",
+      "resolved": "https://mirrors.tencent.com/npm/vue/-/vue-3.5.32.tgz",
+      "integrity": "sha512-vM4z4Q9tTafVfMAK7IVzmxg34rSzTFMyIe0UUEijUCkn9+23lj0WRfA83dg7eQZIUlgOSGrkViIaCfqSAUXsMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.32",
+        "@vue/compiler-sfc": "3.5.32",
+        "@vue/runtime-dom": "3.5.32",
+        "@vue/server-renderer": "3.5.32",
+        "@vue/shared": "3.5.32"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://mirrors.tencent.com/npm/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    }
+  }
+}

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "dcc-mcp-ipc-docs",
+  "version": "1.0.0",
+  "description": "DCC-MCP-IPC Documentation",
+  "scripts": {
+    "docs:dev": "vitepress dev",
+    "docs:build": "vitepress build",
+    "docs:preview": "vitepress preview"
+  },
+  "devDependencies": {
+    "vitepress": "^1.6.4"
+  }
+}

--- a/docs/public/logo.svg
+++ b/docs/public/logo.svg
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="200" height="200" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1E293B;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#0F172A;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient id="dcc-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#F97316;stop-opacity:1" />
+      <stop offset="33%" style="stop-color:#10B981;stop-opacity:1" />
+      <stop offset="66%" style="stop-color:#EF4444;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#8B5CF6;stop-opacity:1" />
+    </linearGradient>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#3B82F6" />
+    </marker>
+  </defs>
+
+  <!-- 背景 -->
+  <rect width="200" height="200" rx="24" fill="url(#bg-gradient)" />
+
+  <!-- RPyC图形 -->
+  <circle cx="70" cy="100" r="28" fill="#3B82F6" />
+  <text x="70" y="105" font-family="Arial, sans-serif" font-weight="bold" font-size="14" text-anchor="middle" fill="white">RPyC</text>
+
+  <!-- DCC图形 -->
+  <circle cx="140" cy="100" r="28" fill="url(#dcc-gradient)" />
+  <text x="140" y="105" font-family="Arial, sans-serif" font-weight="bold" font-size="14" text-anchor="middle" fill="white">DCC</text>
+
+  <!-- 连接箭头 -->
+  <line x1="98" y1="100" x2="112" y2="100" stroke="#3B82F6" stroke-width="3" marker-end="url(#arrow)" />
+
+  <!-- 项目名称 -->
+  <text x="100" y="170" font-family="Arial, sans-serif" font-weight="bold" font-size="16" text-anchor="middle" fill="white">DCC-MCP-RPyC</text>
+</svg>


### PR DESCRIPTION
## Summary

- **Updated README.md and README_zh.md** to accurately reflect the v2.0.0 API: ActionAdapter, SkillManager, all four transports (RPyC, IPC, HTTP, WebSocket), async client, service factories, connection pool, and MockDCCService.
- **VitePress docs site** in `docs/` with full navigation (guide, API reference, examples) — builds to `docs/.vitepress/dist/` with base path `/dcc-mcp-ipc/` for GitHub Pages.
- **GitHub Pages workflow** (`.github/workflows/docs.yml`) auto-deploys on push to `main`.
- **`.gitignore`** updated to exclude `docs/node_modules/`, `docs/.vitepress/dist/`, `docs/.vitepress/cache/`.

## Docs structure

```
docs/
├── index.md                     # Home page
├── guide/                       # Getting started, architecture, all features
├── api/                         # API reference per component
├── examples/                    # Maya, Houdini, Blender, skills, service factories
└── .vitepress/config.mts        # Site config (base=/dcc-mcp-ipc/)
```

## Test plan

- [ ] CI passes (lint, test matrix, build)
- [ ] VitePress build succeeds in the docs workflow
- [ ] After merge to main, GitHub Pages deployment runs and site is accessible at https://loonghao.github.io/dcc-mcp-ipc/