### PR TITLE
feat: improve docs, refresh logo, and add Blender E2E tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,46 +1,40 @@
-# DCC-MCP-IPC
-
 <div align="center">
-    <img src="https://raw.githubusercontent.com/loonghao/dcc-mcp-ipc/main/logo.svg" alt="DCC-MCP-IPC Logo" width="200"/>
+  <img src="https://raw.githubusercontent.com/loonghao/dcc-mcp-ipc/main/logo.svg" alt="DCC-MCP-IPC" width="160"/>
+  <h1>DCC-MCP-IPC</h1>
+  <p><strong>Multi-protocol IPC adapter layer for DCC software integration with <a href="https://modelcontextprotocol.io/">Model Context Protocol (MCP)</a></strong></p>
 
-[![PyPI version](https://badge.fury.io/py/dcc-mcp-ipc.svg)](https://badge.fury.io/py/dcc-mcp-ipc)
-[![CI](https://github.com/loonghao/dcc-mcp-ipc/actions/workflows/ci.yml/badge.svg)](https://github.com/loonghao/dcc-mcp-ipc/actions/workflows/ci.yml)
-[![Python Version](https://img.shields.io/pypi/pyversions/dcc-mcp-ipc.svg)](https://pypi.org/project/dcc-mcp-ipc/)
-[![License](https://img.shields.io/github/license/loonghao/dcc-mcp-ipc.svg)](https://github.com/loonghao/dcc-mcp-ipc/blob/main/LICENSE)
-[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
-[![Ruff](https://img.shields.io/badge/ruff-enabled-brightgreen)](https://github.com/astral-sh/ruff)
+  <p>
+    <a href="https://badge.fury.io/py/dcc-mcp-ipc"><img src="https://badge.fury.io/py/dcc-mcp-ipc.svg" alt="PyPI version"/></a>
+    <a href="https://github.com/loonghao/dcc-mcp-ipc/actions/workflows/ci.yml"><img src="https://github.com/loonghao/dcc-mcp-ipc/actions/workflows/ci.yml/badge.svg" alt="CI"/></a>
+    <a href="https://pypi.org/project/dcc-mcp-ipc/"><img src="https://img.shields.io/pypi/pyversions/dcc-mcp-ipc.svg" alt="Python Version"/></a>
+    <a href="https://github.com/loonghao/dcc-mcp-ipc/blob/main/LICENSE"><img src="https://img.shields.io/github/license/loonghao/dcc-mcp-ipc.svg" alt="License"/></a>
+    <a href="https://github.com/astral-sh/ruff"><img src="https://img.shields.io/badge/ruff-enabled-brightgreen" alt="Ruff"/></a>
+    <a href="https://loonghao.github.io/dcc-mcp-ipc/"><img src="https://img.shields.io/badge/docs-online-blue" alt="Docs"/></a>
+  </p>
+
+  <p>
+    <a href="https://loonghao.github.io/dcc-mcp-ipc/">Documentation</a> ·
+    <a href="./CHANGELOG.md">Changelog</a> ·
+    <a href="./CONTRIBUTING.md">Contributing</a>
+  </p>
 </div>
 
-**Multi-protocol IPC adapter layer for DCC software integration with [Model Context Protocol (MCP)](https://modelcontextprotocol.io/).**
+---
 
-Built on top of **dcc-mcp-core** (Rust/PyO3 backend), it provides a high-performance, type-safe framework for exposing DCC functionality as MCP tools across multiple transport protocols.
+Built on top of **[dcc-mcp-core](https://pypi.org/project/dcc-mcp-core/)** (Rust/PyO3 backend), DCC-MCP-IPC provides a high-performance, type-safe framework for exposing DCC functionality as MCP tools across multiple transport protocols.
 
-> **Documentation**: [docs site](https://loonghao.github.io/dcc-mcp-ipc/) | **v2.0.0** (Unreleased) — Breaking changes ahead, see [CHANGELOG.md](./CHANGELOG.md)
+> **v2.0.0** (Unreleased) — Breaking changes ahead, see [CHANGELOG.md](./CHANGELOG.md)
 
 ## Why DCC-MCP-IPC?
 
 | Feature | Description |
 |---------|-------------|
-| **Protocol-agnostic** | RPyC for embedded-Python DCCs (Maya/Houdini/Blender), HTTP for Unreal/Unity, WebSocket, and Rust-native IPC for maximum throughput. |
-| **Zero-code Skills** | Drop a `SKILL.md` file into a directory — `SkillManager` auto-registers it as an MCP tool. No Python boilerplate needed. |
-| **Rust-powered core** | Action dispatch, validation, and telemetry handled by dcc-mcp-core via PyO3; Python layer focuses on DCC-specific glue code. |
-| **Hot-reload skills** | `SkillWatcher` monitors skill directories and re-registers tools on file changes without restarting the DCC. |
-| **Service discovery** | ZeroConf (mDNS) + file-based fallback for automatic DCC server detection. |
-| **Connection pooling** | `ConnectionPool` with auto-discovery for efficient client-side connection reuse. |
-
-## Features
-
-- Thread-safe RPyC / HTTP / WebSocket / **Rust-native IPC** server implementations
-- **Skills system** — zero-code MCP tool registration from `SKILL.md` frontmatter with hot-reload
-- **Action system** backed by `ActionRegistry` + `ActionDispatcher` (Rust) — JSON-serialised parameter dispatch
-- **Transport factory** — pluggable transport layer (`rpyc`, `http`, `websocket`, `ipc`)
-- Service discovery: ZeroConf (mDNS) + file-based fallback via `ServiceDiscoveryFactory`
-- Async client (`asyncio`) for non-blocking operations
-- Abstract base classes for creating DCC-specific adapters (`DCCAdapter`) and services
-- Application adapter pattern for generic app integration
-- Scene & snapshot interfaces over RPyC and HTTP transports
-- Mock DCC services for testing without actual DCC applications
-- Comprehensive error handling with custom exception hierarchy
+| **Protocol-agnostic** | RPyC for embedded-Python DCCs (Maya/Houdini/Blender), HTTP for Unreal/Unity, WebSocket, and Rust-native IPC for maximum throughput |
+| **Zero-code Skills** | Drop a `SKILL.md` file into a directory — `SkillManager` auto-registers it as an MCP tool, no Python boilerplate needed |
+| **Rust-powered core** | Action dispatch, validation, and telemetry handled by `dcc-mcp-core` via PyO3; Python layer focuses on DCC-specific glue code |
+| **Hot-reload Skills** | `SkillWatcher` monitors skill directories and re-registers tools on file changes without restarting the DCC |
+| **Service discovery** | ZeroConf (mDNS) + file-based fallback for automatic DCC server detection |
+| **Connection pooling** | `ConnectionPool` with auto-discovery for efficient client-side connection reuse |
 
 ## Architecture
 
@@ -48,15 +42,15 @@ Built on top of **dcc-mcp-core** (Rust/PyO3 backend), it provides a high-perform
 graph TD
     A[AI Assistant / MCP Client] --> B[MCP Server Layer]
     B --> C[ActionAdapter\nActionRegistry + ActionDispatcher]
-    C --> D[RPyC Transport\nDCC Python env]
-    C --> E[IPC Transport\nRust FramedChannel]
-    C --> F[HTTP Transport\nUnreal / Unity REST]
-    C --> G[WebSocket Transport]
     G[SkillManager\nSKILL.md auto-discovery] --> C
     H[dcc-mcp-core\nRust/PyO3 backend] --> C
-    D --> I[DCC App\nMaya / Houdini / Blender]
+    C --> D[RPyC Transport\nBlender / Maya / Houdini]
+    C --> E[IPC Transport\nRust FramedChannel]
+    C --> F[HTTP Transport\nUnreal / Unity REST]
+    C --> W[WebSocket Transport]
+    D --> I[DCC Process]
     E --> I
-    F --> J[DCC App\nUnreal / Unity]
+    F --> J[Game Engine / REST DCC]
 
     style C fill:#e1f5fe
     style H fill:#fff3e0
@@ -74,7 +68,7 @@ graph TD
 | `ConnectionPool` | `client/pool.py` | Connection pooling for efficient resource management |
 | `IpcClientTransport` / `IpcServerTransport` | `transport/ipc_transport.py` | Rust-native framed-channel IPC, registered as `"ipc"` protocol |
 | `ServiceDiscoveryFactory` | `discovery/factory.py` | Strategy-pattern selector for ZeroConf or file-based discovery |
-| `MockDCCService` | `testing/mock_services.py` | Simulates DCC applications for testing |
+| `MockDCCService` | `testing/mock_services.py` | Simulates DCC applications for unit and E2E testing |
 
 ## Installation
 
@@ -82,64 +76,62 @@ graph TD
 pip install dcc-mcp-ipc
 ```
 
-With optional ZeroConf support:
+With optional ZeroConf (mDNS) support:
 
 ```bash
 pip install "dcc-mcp-ipc[zeroconf]"
 ```
 
-Or with Poetry:
-
-```bash
-poetry add dcc-mcp-ipc
-```
-
 ### Requirements
 
-- Python >= 3.8 (< 4.0)
-- [dcc-mcp-core](https://pypi.org/project/dcc-mcp-core/) >= 0.12.0 (< 1.0.0)
-- [rpyc](https://rpyc.readthedocs.io/) >= 6.0.0 (< 7.0.0)
+- Python >= 3.8, < 4.0
+- [dcc-mcp-core](https://pypi.org/project/dcc-mcp-core/) >= 0.12.0, < 1.0.0
+- [rpyc](https://rpyc.readthedocs.io/) >= 6.0.0, < 7.0.0
 - Optional: [zeroconf](https://github.com/jstasiak/python-zeroconf) >= 0.38.0 for mDNS discovery
 
 ## Quick Start
 
-### Server-side (within DCC application)
+### Server-side (inside a DCC application)
 
-<augment_code_snippet path="README.md" mode="EXCERPT">
-````python
+```python
 from dcc_mcp_ipc.server import create_dcc_server, DCCRPyCService
 
 
-class MayaService(DCCRPyCService):
-    def get_scene_info(self):
-        return {"scene": "Maya scene info"}
+class BlenderService(DCCRPyCService):
+    def exposed_get_scene_info(self, conn=None):
+        import bpy
+        return {
+            "file": bpy.data.filepath or "untitled",
+            "objects": [obj.name for obj in bpy.data.objects],
+            "frame": bpy.context.scene.frame_current,
+        }
 
-    def exposed_execute_cmd(self, cmd_name, *args, **kwargs):
-        pass
+    def exposed_add_primitive(self, ptype="SPHERE", location=(0, 0, 0), conn=None):
+        import bpy
+        bpy.ops.mesh.primitive_uv_sphere_add(location=location)
+        return {"success": True, "name": bpy.context.object.name}
 
 
-server = create_dcc_server(
-    dcc_name="maya",
-    service_class=MayaService,
-    port=18812,
-)
+server = create_dcc_server(dcc_name="blender", service_class=BlenderService, port=18814)
 server.start(threaded=True)
-````
-</augment_code_snippet>
+```
 
 ### Client-side
 
-<augment_code_snippet path="README.md" mode="EXCERPT">
-````python
+```python
 from dcc_mcp_ipc.client import BaseDCCClient
 
-
-client = BaseDCCClient("maya", host="localhost", port=18812)
+client = BaseDCCClient("blender", host="localhost", port=18814)
 client.connect()
-result = client.call("get_scene_info")
+
+info = client.call("get_scene_info")
+print(f"Scene: {info['file']}, Objects: {info['objects']}")
+
+result = client.call("add_primitive", ptype="SPHERE", location=[1, 0, 0])
+print(f"Created: {result['name']}")
+
 client.disconnect()
-````
-</augment_code_snippet>
+```
 
 ## Usage Guide
 
@@ -147,15 +139,13 @@ client.disconnect()
 
 The Action system is built on the Rust-backed `ActionRegistry` + `ActionDispatcher`. All parameters are JSON-serialised:
 
-<augment_code_snippet path="README.md" mode="EXCERPT">
-````python
-from dcc_mcp_ipc.action_adapter import ActionAdapter, get_action_adapter
+```python
+from dcc_mcp_ipc.action_adapter import get_action_adapter
+
+adapter = get_action_adapter("blender")
 
 
-adapter = get_action_adapter("maya")
-
-
-def create_sphere(radius: float = 1.0, name: str = "sphere1") -> dict:
+def create_sphere(radius: float = 1.0, name: str = "Sphere") -> dict:
     return {"success": True, "message": f"Created {name}", "context": {"name": name}}
 
 
@@ -167,104 +157,95 @@ adapter.register_action(
     tags=["primitive", "mesh"],
 )
 
-
-result = adapter.call_action("create_sphere", radius=2.0, name="mySphere")
-print(result.success)   # True
-print(result.to_dict()) # {"success": True, ...}
-````
-</augment_code_snippet>
+result = adapter.call_action("create_sphere", radius=2.0, name="MySphere")
+print(result.success)    # True
+print(result.to_dict())  # {"success": True, ...}
+```
 
 ### Zero-code Skills via SkillManager
 
-Drop a `SKILL.md` file into a directory structure:
+Drop a `SKILL.md` file into a directory and `SkillManager` auto-registers it as an MCP tool:
 
 ```
 my_skills/
   create_light/
-    SKILL.md      # frontmatter: name, description, tools, scripts
-    run.py        # executed when the tool is called
+    SKILL.md    # frontmatter: name, description, tools, scripts
+    run.py      # executed when the tool is called
 ```
 
-<augment_code_snippet path="README.md" mode="EXCERPT">
-````python
+```python
 from dcc_mcp_ipc.skills import SkillManager
 from dcc_mcp_ipc.action_adapter import get_action_adapter
 
-
-adapter = get_action_adapter("maya")
-mgr = SkillManager(adapter=adapter, dcc_name="maya")
+adapter = get_action_adapter("blender")
+mgr = SkillManager(adapter=adapter, dcc_name="blender")
 
 mgr.load_paths(["/pipeline/skills"])
-mgr.start_watching()
+mgr.start_watching()  # hot-reload on file changes
 
-# Now "create_light" is callable as an MCP tool
 result = adapter.call_action("create_light", intensity=100.0)
-````
-</augment_code_snippet>
+```
 
 ### Connection Pool
 
-<augment_code_snippet path="README.md" mode="EXCERPT">
-````python
+```python
 from dcc_mcp_ipc.client import ConnectionPool
-
 
 pool = ConnectionPool()
 
-with pool.get_client("maya", host="localhost") as client:
-    result = client.call("execute_cmd", "sphere", radius=5)
+with pool.get_client("blender", host="localhost") as client:
+    result = client.call("get_scene_info")
     print(result)
-````
-</augment_code_snippet>
+```
+
+### Async Client
+
+```python
+import asyncio
+from dcc_mcp_ipc.client.async_dcc import AsyncDCCClient
+
+
+async def main():
+    client = AsyncDCCClient("blender", host="localhost", port=18814)
+    await client.connect()
+    result = await client.call("get_scene_info")
+    await client.disconnect()
+    return result
+
+
+asyncio.run(main())
+```
 
 ### Service Factories
 
-Three factory patterns are available for different lifecycle needs:
+Three factory patterns for different lifecycle needs:
 
-<augment_code_snippet path="README.md" mode="EXCERPT">
-````python
+```python
 from dcc_mcp_ipc.server import (
     create_service_factory,
     create_shared_service_instance,
     create_raw_threaded_server,
 )
 
-
-class SceneManager:
-    def __init__(self):
-        self.scenes = {}
-
-    def add_scene(self, name, data):
-        self.scenes[name] = data
-
-
-scene_manager = SceneManager()
-
 # Per-connection instance
-service_factory = create_service_factory(MayaService, scene_manager)
+service_factory = create_service_factory(BlenderService, scene_manager)
 
-# Shared singleton instance
-shared_service = create_shared_service_instance(MayaService, scene_manager)
+# Shared singleton across all connections
+shared_service = create_shared_service_instance(BlenderService, scene_manager)
 
 # Raw threaded server
-server = create_raw_threaded_server(service_factory, port=18812)
+server = create_raw_threaded_server(service_factory, port=18814)
 server.start()
-````
-</augment_code_snippet>
+```
 
 ### Rust-native IPC Transport
 
-Zero-copy low-latency messaging via the Rust core:
+Zero-copy, low-latency messaging via the Rust core:
 
-<augment_code_snippet path="README.md" mode="EXCERPT">
-````python
+```python
 import os
 from dcc_mcp_core import TransportAddress
-from dcc_mcp_ipc.transport.ipc_transport import (
-    IpcClientTransport,
-    IpcServerTransport,
-    IpcTransportConfig,
-)
+from dcc_mcp_ipc.transport.ipc_transport import IpcClientTransport, IpcServerTransport, IpcTransportConfig
 
 # Client side
 config = IpcTransportConfig(host="localhost", port=19000)
@@ -274,78 +255,26 @@ result = transport.execute("get_scene_info")
 transport.disconnect()
 
 # Server side (inside DCC plugin)
-def handle_channel(channel):
-    msg = channel.recv()
-    # process and respond ...
-
-addr = TransportAddress.default_local("maya", os.getpid())
-server = IpcServerTransport(addr, handler=handle_channel)
+addr = TransportAddress.default_local("blender", os.getpid())
+server = IpcServerTransport(addr, handler=lambda ch: ch.recv())
 bound_addr = server.start()
-````
-</augment_code_snippet>
-
-### Creating a Custom DCC Adapter
-
-<augment_code_snippet path="README.md" mode="EXCERPT">
-````python
-from dcc_mcp_ipc.adapter import DCCAdapter
-from dcc_mcp_ipc.client import BaseDCCClient
-
-
-class MayaAdapter(DCCAdapter):
-    def _initialize_client(self) -> None:
-        self.client = BaseDCCClient(
-            dcc_name="maya",
-            host=self.host,
-            port=self.port,
-            connection_timeout=self.connection_timeout,
-        )
-
-    def create_sphere(self, radius: float = 1.0):
-        self.ensure_connected()
-        assert self.client is not None
-        return self.client.execute_dcc_command(f"sphere -r {radius};")
-````
-</augment_code_snippet>
-
-### Async Client
-
-<augment_code_snippet path="README.md" mode="EXCERPT">
-````python
-import asyncio
-from dcc_mcp_ipc.client.async_dcc import AsyncDCCClient
-
-
-async def main():
-    client = AsyncDCCClient("maya", host="localhost", port=18812)
-    await client.connect()
-    result = await client.call("get_scene_info")
-    await client.disconnect()
-
-
-asyncio.run(main())
-````
-</augment_code_snippet>
+```
 
 ### Testing with Mock Services
 
-<augment_code_snippet path="README.md" mode="EXCERPT">
-````python
-import threading
+```python
 from dcc_mcp_ipc.testing.mock_services import MockDCCService
 from dcc_mcp_ipc.client import BaseDCCClient
 
+server = MockDCCService.start(port=18814)
 
-server = MockDCCService.start(port=18812)
-
-client = BaseDCCClient("mock_dcc", host="localhost", port=18812)
+client = BaseDCCClient("mock_dcc", host="localhost", port=18814)
 client.connect()
 info = client.get_dcc_info()
 print(info)  # {"name": "mock_dcc", ...}
 client.disconnect()
 server.stop()
-````
-</augment_code_snippet>
+```
 
 ## Development
 
@@ -360,8 +289,8 @@ poetry install
 ### Running Tasks
 
 ```bash
-nox -s pytest          # Run tests
-nox -s lint            # Lint (mypy + ruff + isort)
+nox -s pytest          # Run all tests (unit + E2E)
+nox -s lint            # Lint: mypy + ruff + isort
 nox -s lint-fix        # Auto-fix lint issues
 nox -s build           # Build distribution packages
 ```
@@ -371,23 +300,25 @@ nox -s build           # Build distribution packages
 ```
 dcc-mcp-ipc/
 ├── src/dcc_mcp_ipc/
-│   ├── __init__.py              # Lazy-import public API surface
-│   ├── action_adapter.py         # Action system (Rust-backed)
-│   ├── adapter/                  # DCC & application adapters
-│   ├── client/                   # Synchronous & async clients + pool
-│   ├── server/                   # RPyC server + factories + lifecycle
-│   ├── transport/                # RPyC / HTTP / WS / IPC transports
-│   ├── discovery/                # ZeroConf + file-based service discovery
-│   ├── skills/                   # SkillManager zero-code system
-│   ├── scene/                    # Scene operations interface
-│   ├── snapshot/                 # Snapshot interface
-│   ├── application/              # Generic application adapter/service/client
-│   ├── testing/                  # Mock services for testing
-│   └── utils/                    # Errors, DI, decorators, RPyC helpers
-├── tests/                        # 68 test files mirroring source layout
-├── examples/                     # Usage examples
-├── docs/                         # VitePress documentation site
-└── nox_actions/                  # Nox task definitions
+│   ├── __init__.py          # Lazy-import public API
+│   ├── action_adapter.py    # Action system (Rust-backed)
+│   ├── adapter/             # DCC & application adapters
+│   ├── client/              # Sync & async clients + connection pool
+│   ├── server/              # RPyC server + factories + lifecycle
+│   ├── transport/           # RPyC / HTTP / WebSocket / IPC transports
+│   ├── discovery/           # ZeroConf + file-based service discovery
+│   ├── skills/              # SkillManager zero-code system
+│   ├── scene/               # Scene operations interface
+│   ├── snapshot/            # Snapshot interface
+│   ├── application/         # Generic application adapter/service/client
+│   ├── testing/             # Mock services for testing
+│   └── utils/               # Errors, DI, decorators, RPyC helpers
+├── tests/
+│   ├── e2e/                 # End-to-end tests (Blender, Maya, Houdini)
+│   └── ...                  # Unit tests mirroring source layout
+├── examples/                # Usage examples
+├── docs/                    # VitePress documentation site
+└── nox_actions/             # Nox task definitions
 ```
 
 ## License

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,46 +1,40 @@
-# DCC-MCP-IPC
-
 <div align="center">
-    <img src="https://raw.githubusercontent.com/loonghao/dcc-mcp-ipc/main/logo.svg" alt="DCC-MCP-IPC Logo" width="200"/>
+  <img src="https://raw.githubusercontent.com/loonghao/dcc-mcp-ipc/main/logo.svg" alt="DCC-MCP-IPC" width="160"/>
+  <h1>DCC-MCP-IPC</h1>
+  <p><strong>DCC 软件与 <a href="https://modelcontextprotocol.io/">模型上下文协议 (MCP)</a> 集成的多协议 IPC 适配层</strong></p>
 
-[![PyPI version](https://badge.fury.io/py/dcc-mcp-ipc.svg)](https://badge.fury.io/py/dcc-mcp-ipc)
-[![CI](https://github.com/loonghao/dcc-mcp-ipc/actions/workflows/ci.yml/badge.svg)](https://github.com/loonghao/dcc-mcp-ipc/actions/workflows/ci.yml)
-[![Python Version](https://img.shields.io/pypi/pyversions/dcc-mcp-ipc.svg)](https://pypi.org/project/dcc-mcp-ipc/)
-[![License](https://img.shields.io/github/license/loonghao/dcc-mcp-ipc.svg)](https://github.com/loonghao/dcc-mcp-ipc/blob/main/LICENSE)
-[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
-[![Ruff](https://img.shields.io/badge/ruff-enabled-brightgreen)](https://github.com/astral-sh/ruff)
+  <p>
+    <a href="https://badge.fury.io/py/dcc-mcp-ipc"><img src="https://badge.fury.io/py/dcc-mcp-ipc.svg" alt="PyPI version"/></a>
+    <a href="https://github.com/loonghao/dcc-mcp-ipc/actions/workflows/ci.yml"><img src="https://github.com/loonghao/dcc-mcp-ipc/actions/workflows/ci.yml/badge.svg" alt="CI"/></a>
+    <a href="https://pypi.org/project/dcc-mcp-ipc/"><img src="https://img.shields.io/pypi/pyversions/dcc-mcp-ipc.svg" alt="Python Version"/></a>
+    <a href="https://github.com/loonghao/dcc-mcp-ipc/blob/main/LICENSE"><img src="https://img.shields.io/github/license/loonghao/dcc-mcp-ipc.svg" alt="License"/></a>
+    <a href="https://github.com/astral-sh/ruff"><img src="https://img.shields.io/badge/ruff-enabled-brightgreen" alt="Ruff"/></a>
+    <a href="https://loonghao.github.io/dcc-mcp-ipc/"><img src="https://img.shields.io/badge/文档-在线-blue" alt="Docs"/></a>
+  </p>
+
+  <p>
+    <a href="https://loonghao.github.io/dcc-mcp-ipc/">文档</a> ·
+    <a href="./CHANGELOG.md">更新日志</a> ·
+    <a href="./CONTRIBUTING.md">贡献指南</a>
+  </p>
 </div>
 
-**DCC 软件与 [模型上下文协议 (MCP)](https://modelcontextprotocol.io/) 集成的多协议 IPC 适配层。**
+---
 
-基于 **dcc-mcp-core**（Rust/PyO3 后端）构建，为将 DCC 功能作为 MCP 工具暴露提供高性能、类型安全的框架，支持多种传输协议。
+基于 **[dcc-mcp-core](https://pypi.org/project/dcc-mcp-core/)（Rust/PyO3 后端）** 构建，DCC-MCP-IPC 为将 DCC 功能作为 MCP 工具暴露提供高性能、类型安全的框架，支持多种传输协议。
 
-> **文档**: [文档站点](https://loonghao.github.io/dcc-mcp-ipc/) | **v2.0.0**（未发布）— 包含破坏性变更，请参阅 [CHANGELOG.md](./CHANGELOG.md)
+> **v2.0.0**（未发布）— 包含破坏性变更，请参阅 [CHANGELOG.md](./CHANGELOG.md)
 
 ## 为什么选择 DCC-MCP-IPC？
 
 | 特性 | 说明 |
 |------|------|
-| **协议无关** | RPyC 用于内嵌 Python 的 DCC（Maya/Houdini/Blender），HTTP 用于 Unreal/Unity，WebSocket，以及 Rust 原生 IPC 通道提供最高吞吐量。 |
-| **零代码 Skills** | 在目录中放置一个 `SKILL.md` 文件，`SkillManager` 就会自动将其注册为 MCP 工具，无需 Python 样板代码。 |
-| **Rust 性能核心** | Action 派发、验证和遥测由 dcc-mcp-core 通过 PyO3 处理；Python 层专注于 DCC 特定的胶水代码。 |
-| **热重载 Skills** | `SkillWatcher` 监控 skill 目录，文件变更时无需重启 DCC 即可重新注册工具。 |
-| **服务发现** | ZeroConf（mDNS）+ 文件备份策略，自动检测 DCC 服务器。 |
-| **连接池** | `ConnectionPool` 支持自动发现，实现高效的客户端连接复用。 |
-
-## 功能特性
-
-- 线程安全的 RPyC / HTTP / WebSocket / **Rust 原生 IPC** 服务器实现
-- **Skills 系统** — 通过 `SKILL.md` frontmatter 进行零代码 MCP 工具注册，支持热重载
-- **Action 系统** — 基于 `ActionRegistry` + `ActionDispatcher`（Rust），使用 JSON 序列化参数派发
-- **传输工厂** — 可插拔传输层（`rpyc`、`http`、`websocket`、`ipc`）
-- 服务发现：ZeroConf（mDNS）+ 文件备份策略，通过 `ServiceDiscoveryFactory` 统一管理
-- 异步客户端（asyncio）支持非阻塞操作
-- 提供抽象基类，用于创建特定 DCC 的适配器（`DCCAdapter`）和服务
-- 应用适配器模式，支持通用应用集成
-- 通过 RPyC 和 HTTP 传输的场景与快照接口
-- 模拟 DCC 服务，用于无需实际 DCC 应用程序的测试
-- 包含自定义异常体系的全面错误处理
+| **协议无关** | RPyC 用于内嵌 Python 的 DCC（Maya/Houdini/Blender），HTTP 用于 Unreal/Unity，WebSocket，以及 Rust 原生 IPC 通道提供最高吞吐量 |
+| **零代码 Skills** | 在目录中放置一个 `SKILL.md` 文件，`SkillManager` 就会自动将其注册为 MCP 工具，无需 Python 样板代码 |
+| **Rust 性能核心** | Action 派发、验证和遥测由 `dcc-mcp-core` 通过 PyO3 处理；Python 层专注于 DCC 特定的胶水代码 |
+| **热重载 Skills** | `SkillWatcher` 监控 skill 目录，文件变更时无需重启 DCC 即可重新注册工具 |
+| **服务发现** | ZeroConf（mDNS）+ 文件备份策略，自动检测 DCC 服务器 |
+| **连接池** | `ConnectionPool` 支持自动发现，实现高效的客户端连接复用 |
 
 ## 架构
 
@@ -48,15 +42,15 @@
 graph TD
     A[AI 助手 / MCP 客户端] --> B[MCP 服务器层]
     B --> C[ActionAdapter\nActionRegistry + ActionDispatcher]
-    C --> D[RPyC 传输\nDCC Python 环境]
-    C --> E[IPC 传输\nRust FramedChannel]
-    C --> F[HTTP 传输\nUnreal / Unity REST]
-    C --> G[WebSocket 传输]
     G[SkillManager\nSKILL.md 自动发现] --> C
     H[dcc-mcp-core\nRust/PyO3 后端] --> C
-    D --> I[DCC 应用\nMaya / Houdini / Blender]
+    C --> D[RPyC 传输\nBlender / Maya / Houdini]
+    C --> E[IPC 传输\nRust FramedChannel]
+    C --> F[HTTP 传输\nUnreal / Unity REST]
+    C --> W[WebSocket 传输]
+    D --> I[DCC 进程]
     E --> I
-    F --> J[DCC 应用\nUnreal / Unity]
+    F --> J[游戏引擎 / REST DCC]
 
     style C fill:#e1f5fe
     style H fill:#fff3e0
@@ -74,7 +68,7 @@ graph TD
 | `ConnectionPool` | `client/pool.py` | 连接池，高效管理客户端连接资源 |
 | `IpcClientTransport` / `IpcServerTransport` | `transport/ipc_transport.py` | Rust 原生帧通道 IPC，注册为 `"ipc"` 协议 |
 | `ServiceDiscoveryFactory` | `discovery/factory.py` | ZeroConf 或文件服务发现的策略模式选择器 |
-| `MockDCCService` | `testing/mock_services.py` | 模拟 DCC 应用程序用于测试 |
+| `MockDCCService` | `testing/mock_services.py` | 模拟 DCC 应用程序，用于单元测试和 E2E 测试 |
 
 ## 安装
 
@@ -82,23 +76,17 @@ graph TD
 pip install dcc-mcp-ipc
 ```
 
-安装可选的 ZeroConf 支持：
+安装可选的 ZeroConf（mDNS）支持：
 
 ```bash
 pip install "dcc-mcp-ipc[zeroconf]"
 ```
 
-或者使用 Poetry：
-
-```bash
-poetry add dcc-mcp-ipc
-```
-
 ### 依赖要求
 
-- Python >= 3.8 (< 4.0)
-- [dcc-mcp-core](https://pypi.org/project/dcc-mcp-core/) >= 0.12.0 (< 1.0.0)
-- [rpyc](https://rpyc.readthedocs.io/) >= 6.0.0 (< 7.0.0)
+- Python >= 3.8, < 4.0
+- [dcc-mcp-core](https://pypi.org/project/dcc-mcp-core/) >= 0.12.0, < 1.0.0
+- [rpyc](https://rpyc.readthedocs.io/) >= 6.0.0, < 7.0.0
 - 可选：[zeroconf](https://github.com/jstasiak/python-zeroconf) >= 0.38.0（mDNS 发现）
 
 ## 快速上手
@@ -109,19 +97,22 @@ poetry add dcc-mcp-ipc
 from dcc_mcp_ipc.server import create_dcc_server, DCCRPyCService
 
 
-class MayaService(DCCRPyCService):
-    def get_scene_info(self):
-        return {"scene": "Maya 场景信息"}
+class BlenderService(DCCRPyCService):
+    def exposed_get_scene_info(self, conn=None):
+        import bpy
+        return {
+            "file": bpy.data.filepath or "untitled",
+            "objects": [obj.name for obj in bpy.data.objects],
+            "frame": bpy.context.scene.frame_current,
+        }
 
-    def exposed_execute_cmd(self, cmd_name, *args, **kwargs):
-        pass
+    def exposed_add_primitive(self, ptype="SPHERE", location=(0, 0, 0), conn=None):
+        import bpy
+        bpy.ops.mesh.primitive_uv_sphere_add(location=location)
+        return {"success": True, "name": bpy.context.object.name}
 
 
-server = create_dcc_server(
-    dcc_name="maya",
-    service_class=MayaService,
-    port=18812,
-)
+server = create_dcc_server(dcc_name="blender", service_class=BlenderService, port=18814)
 server.start(threaded=True)
 ```
 
@@ -130,10 +121,15 @@ server.start(threaded=True)
 ```python
 from dcc_mcp_ipc.client import BaseDCCClient
 
-
-client = BaseDCCClient("maya", host="localhost", port=18812)
+client = BaseDCCClient("blender", host="localhost", port=18814)
 client.connect()
-result = client.call("get_scene_info")
+
+info = client.call("get_scene_info")
+print(f"场景：{info['file']}，对象：{info['objects']}")
+
+result = client.call("add_primitive", ptype="SPHERE", location=[1, 0, 0])
+print(f"已创建：{result['name']}")
+
 client.disconnect()
 ```
 
@@ -144,13 +140,12 @@ client.disconnect()
 Action 系统基于 Rust 后端的 `ActionRegistry` + `ActionDispatcher` 构建，所有参数均使用 JSON 序列化：
 
 ```python
-from dcc_mcp_ipc.action_adapter import ActionAdapter, get_action_adapter
+from dcc_mcp_ipc.action_adapter import get_action_adapter
+
+adapter = get_action_adapter("blender")
 
 
-adapter = get_action_adapter("maya")
-
-
-def create_sphere(radius: float = 1.0, name: str = "sphere1") -> dict:
+def create_sphere(radius: float = 1.0, name: str = "Sphere") -> dict:
     return {"success": True, "message": f"Created {name}", "context": {"name": name}}
 
 
@@ -162,35 +157,32 @@ adapter.register_action(
     tags=["primitive", "mesh"],
 )
 
-
-result = adapter.call_action("create_sphere", radius=2.0, name="mySphere")
-print(result.success)   # True
-print(result.to_dict()) # {"success": True, ...}
+result = adapter.call_action("create_sphere", radius=2.0, name="MySphere")
+print(result.success)    # True
+print(result.to_dict())  # {"success": True, ...}
 ```
 
 ### 通过 SkillManager 实现零代码 Skills
 
-在目录结构中放置 `SKILL.md` 文件：
+在目录中放置 `SKILL.md` 文件，`SkillManager` 自动将其注册为 MCP 工具：
 
 ```
 my_skills/
   create_light/
-    SKILL.md      # frontmatter: name, description, tools, scripts
-    run.py        # 工具被调用时执行此文件
+    SKILL.md    # frontmatter: name, description, tools, scripts
+    run.py      # 工具被调用时执行此文件
 ```
 
 ```python
 from dcc_mcp_ipc.skills import SkillManager
 from dcc_mcp_ipc.action_adapter import get_action_adapter
 
-
-adapter = get_action_adapter("maya")
-mgr = SkillManager(adapter=adapter, dcc_name="maya")
+adapter = get_action_adapter("blender")
+mgr = SkillManager(adapter=adapter, dcc_name="blender")
 
 mgr.load_paths(["/pipeline/skills"])
-mgr.start_watching()
+mgr.start_watching()  # 文件变更时热重载
 
-# 现在 "create_light" 可作为 MCP 工具调用
 result = adapter.call_action("create_light", intensity=100.0)
 ```
 
@@ -199,12 +191,29 @@ result = adapter.call_action("create_light", intensity=100.0)
 ```python
 from dcc_mcp_ipc.client import ConnectionPool
 
-
 pool = ConnectionPool()
 
-with pool.get_client("maya", host="localhost") as client:
-    result = client.call("execute_cmd", "sphere", radius=5)
+with pool.get_client("blender", host="localhost") as client:
+    result = client.call("get_scene_info")
     print(result)
+```
+
+### 异步客户端
+
+```python
+import asyncio
+from dcc_mcp_ipc.client.async_dcc import AsyncDCCClient
+
+
+async def main():
+    client = AsyncDCCClient("blender", host="localhost", port=18814)
+    await client.connect()
+    result = await client.call("get_scene_info")
+    await client.disconnect()
+    return result
+
+
+asyncio.run(main())
 ```
 
 ### 服务工厂
@@ -218,25 +227,14 @@ from dcc_mcp_ipc.server import (
     create_raw_threaded_server,
 )
 
-
-class SceneManager:
-    def __init__(self):
-        self.scenes = {}
-
-    def add_scene(self, name, data):
-        self.scenes[name] = data
-
-
-scene_manager = SceneManager()
-
 # 每连接一个新实例
-service_factory = create_service_factory(MayaService, scene_manager)
+service_factory = create_service_factory(BlenderService, scene_manager)
 
 # 所有连接共享单一实例
-shared_service = create_shared_service_instance(MayaService, scene_manager)
+shared_service = create_shared_service_instance(BlenderService, scene_manager)
 
 # 原始线程服务器
-server = create_raw_threaded_server(service_factory, port=18812)
+server = create_raw_threaded_server(service_factory, port=18814)
 server.start()
 ```
 
@@ -247,11 +245,7 @@ server.start()
 ```python
 import os
 from dcc_mcp_core import TransportAddress
-from dcc_mcp_ipc.transport.ipc_transport import (
-    IpcClientTransport,
-    IpcServerTransport,
-    IpcTransportConfig,
-)
+from dcc_mcp_ipc.transport.ipc_transport import IpcClientTransport, IpcServerTransport, IpcTransportConfig
 
 # 客户端
 config = IpcTransportConfig(host="localhost", port=19000)
@@ -261,52 +255,9 @@ result = transport.execute("get_scene_info")
 transport.disconnect()
 
 # 服务器端（DCC 插件内）
-def handle_channel(channel):
-    msg = channel.recv()
-    # 处理并响应...
-
-addr = TransportAddress.default_local("maya", os.getpid())
-server = IpcServerTransport(addr, handler=handle_channel)
+addr = TransportAddress.default_local("blender", os.getpid())
+server = IpcServerTransport(addr, handler=lambda ch: ch.recv())
 bound_addr = server.start()
-```
-
-### 创建自定义 DCC 适配器
-
-```python
-from dcc_mcp_ipc.adapter import DCCAdapter
-from dcc_mcp_ipc.client import BaseDCCClient
-
-
-class MayaAdapter(DCCAdapter):
-    def _initialize_client(self) -> None:
-        self.client = BaseDCCClient(
-            dcc_name="maya",
-            host=self.host,
-            port=self.port,
-            connection_timeout=self.connection_timeout,
-        )
-
-    def create_sphere(self, radius: float = 1.0):
-        self.ensure_connected()
-        assert self.client is not None
-        return self.client.execute_dcc_command(f"sphere -r {radius};")
-```
-
-### 异步客户端
-
-```python
-import asyncio
-from dcc_mcp_ipc.client.async_dcc import AsyncDCCClient
-
-
-async def main():
-    client = AsyncDCCClient("maya", host="localhost", port=18812)
-    await client.connect()
-    result = await client.call("get_scene_info")
-    await client.disconnect()
-
-
-asyncio.run(main())
 ```
 
 ### 使用模拟服务进行测试
@@ -315,10 +266,9 @@ asyncio.run(main())
 from dcc_mcp_ipc.testing.mock_services import MockDCCService
 from dcc_mcp_ipc.client import BaseDCCClient
 
+server = MockDCCService.start(port=18814)
 
-server = MockDCCService.start(port=18812)
-
-client = BaseDCCClient("mock_dcc", host="localhost", port=18812)
+client = BaseDCCClient("mock_dcc", host="localhost", port=18814)
 client.connect()
 info = client.get_dcc_info()
 print(info)  # {"name": "mock_dcc", ...}
@@ -339,8 +289,8 @@ poetry install
 ### 常用命令
 
 ```bash
-nox -s pytest          # 运行测试
-nox -s lint            # 代码检查（mypy + ruff + isort）
+nox -s pytest          # 运行所有测试（单元 + E2E）
+nox -s lint            # 代码检查：mypy + ruff + isort
 nox -s lint-fix        # 自动修复代码规范问题
 nox -s build           # 构建发布包
 ```
@@ -350,23 +300,25 @@ nox -s build           # 构建发布包
 ```
 dcc-mcp-ipc/
 ├── src/dcc_mcp_ipc/
-│   ├── __init__.py              # 懒加载公共 API 入口
-│   ├── action_adapter.py         # Action 系统（Rust 后端）
-│   ├── adapter/                  # DCC 和应用适配器
-│   ├── client/                   # 同步/异步客户端 + 连接池
-│   ├── server/                   # RPyC 服务器 + 工厂 + 生命周期
-│   ├── transport/                # RPyC / HTTP / WS / IPC 传输层
-│   ├── discovery/                # ZeroConf + 文件服务发现
-│   ├── skills/                   # SkillManager 零代码系统
-│   ├── scene/                    # 场景操作接口
-│   ├── snapshot/                 # 快照接口
-│   ├── application/              # 通用应用适配器/服务/客户端
-│   ├── testing/                  # 测试用模拟服务
-│   └── utils/                    # 错误、DI、装饰器、RPyC 工具
-├── tests/                        # 68 个测试文件，与源码结构对应
-├── examples/                     # 使用示例
-├── docs/                         # VitePress 文档站点
-└── nox_actions/                  # Nox 任务定义
+│   ├── __init__.py          # 懒加载公共 API 入口
+│   ├── action_adapter.py    # Action 系统（Rust 后端）
+│   ├── adapter/             # DCC 和应用适配器
+│   ├── client/              # 同步/异步客户端 + 连接池
+│   ├── server/              # RPyC 服务器 + 工厂 + 生命周期
+│   ├── transport/           # RPyC / HTTP / WebSocket / IPC 传输层
+│   ├── discovery/           # ZeroConf + 文件服务发现
+│   ├── skills/              # SkillManager 零代码系统
+│   ├── scene/               # 场景操作接口
+│   ├── snapshot/            # 快照接口
+│   ├── application/         # 通用应用适配器/服务/客户端
+│   ├── testing/             # 测试用模拟服务
+│   └── utils/               # 错误、DI、装饰器、RPyC 工具
+├── tests/
+│   ├── e2e/                 # 端到端测试（Blender、Maya、Houdini）
+│   └── ...                  # 与源码结构对应的单元测试
+├── examples/                # 使用示例
+├── docs/                    # VitePress 文档站点
+└── nox_actions/             # Nox 任务定义
 ```
 
 ## 许可证

--- a/docs/examples/blender.md
+++ b/docs/examples/blender.md
@@ -1,50 +1,147 @@
 # Blender Integration
 
-## Setup
+This guide shows how to integrate **DCC-MCP-IPC** with [Blender](https://www.blender.org/) to expose Blender's Python API (`bpy`) as MCP tools.
 
-Install `dcc-mcp-ipc` in Blender's bundled Python:
+## Prerequisites
+
+- Blender 3.x or 4.x (with bundled Python 3.10+)
+- `dcc-mcp-ipc` installed in Blender's Python environment
+
+## Installation
+
+Install `dcc-mcp-ipc` into Blender's bundled Python interpreter:
 
 ```bash
-# Find Blender's Python
+# Blender 4.x on macOS
 /Applications/Blender.app/Contents/Resources/4.x/python/bin/python3.11 -m pip install dcc-mcp-ipc
+
+# Blender 4.x on Linux
+/path/to/blender/4.x/python/bin/python3.11 -m pip install dcc-mcp-ipc
+
+# Blender 4.x on Windows
+"C:\Program Files\Blender Foundation\Blender 4.x\4.x\python\bin\python.exe" -m pip install dcc-mcp-ipc
 ```
 
-## Server (Blender addon or script)
+## Server (Blender Add-on or Script)
+
+Run this inside Blender's scripting workspace or package it as an add-on:
 
 ```python
 import threading
 from dcc_mcp_ipc.server import create_dcc_server, DCCRPyCService
 
+BLENDER_IPC_PORT = 18814
+
 
 class BlenderService(DCCRPyCService):
+    """Blender RPyC service — exposes bpy operations over IPC."""
+
     def exposed_get_scene_info(self, conn=None):
+        """Return metadata about the current Blender scene."""
         import bpy
         return {
             "file": bpy.data.filepath or "untitled",
             "objects": [obj.name for obj in bpy.data.objects],
-            "frame": bpy.context.scene.frame_current,
+            "frame_current": bpy.context.scene.frame_current,
+            "frame_start": bpy.context.scene.frame_start,
+            "frame_end": bpy.context.scene.frame_end,
+            "render_engine": bpy.context.scene.render.engine,
         }
 
     def exposed_add_primitive(self, ptype="SPHERE", location=(0, 0, 0), conn=None):
+        """Add a mesh primitive to the scene.
+
+        Args:
+            ptype: One of SPHERE, CUBE, CYLINDER, CONE, TORUS, PLANE.
+            location: (x, y, z) world-space coordinates.
+
+        Returns:
+            dict with success flag and the new object's name.
+        """
         import bpy
-        bpy.ops.mesh.primitive_uv_sphere_add(location=location)
+
+        loc = tuple(location)
+        dispatch = {
+            "SPHERE": bpy.ops.mesh.primitive_uv_sphere_add,
+            "CUBE": bpy.ops.mesh.primitive_cube_add,
+            "CYLINDER": bpy.ops.mesh.primitive_cylinder_add,
+            "CONE": bpy.ops.mesh.primitive_cone_add,
+            "TORUS": bpy.ops.mesh.primitive_torus_add,
+            "PLANE": bpy.ops.mesh.primitive_plane_add,
+        }
+        op = dispatch.get(ptype.upper(), bpy.ops.mesh.primitive_uv_sphere_add)
+        op(location=loc)
         obj = bpy.context.object
-        return {"success": True, "name": obj.name}
+        return {"success": True, "name": obj.name, "type": ptype}
+
+    def exposed_set_object_location(self, name, location, conn=None):
+        """Move an existing object to a new world-space location."""
+        import bpy
+
+        obj = bpy.data.objects.get(name)
+        if obj is None:
+            return {"success": False, "error": f"Object '{name}' not found"}
+        obj.location = location
+        return {"success": True, "name": name, "location": list(obj.location)}
+
+    def exposed_delete_object(self, name, conn=None):
+        """Delete an object by name."""
+        import bpy
+
+        obj = bpy.data.objects.get(name)
+        if obj is None:
+            return {"success": False, "error": f"Object '{name}' not found"}
+        bpy.data.objects.remove(obj, do_unlink=True)
+        return {"success": True, "deleted": name}
+
+    def exposed_render_preview(self, output_path="/tmp/preview.png", conn=None):
+        """Render a preview frame to disk."""
+        import bpy
+
+        bpy.context.scene.render.filepath = output_path
+        bpy.ops.render.render(write_still=True)
+        return {"success": True, "output": output_path}
 
     def exposed_execute_python(self, code, conn=None):
+        """Execute arbitrary Python code with `bpy` in scope.
+
+        The code may set ``_result`` to return a value.
+
+        .. warning::
+            Use only in trusted, local development environments.
+        """
         import bpy
-        local_vars = {}
-        exec(code, {"bpy": bpy}, local_vars)
+
+        local_vars: dict = {}
+        exec(code, {"bpy": bpy}, local_vars)  # noqa: S102
         return local_vars.get("_result")
 
 
-server = create_dcc_server(dcc_name="blender", service_class=BlenderService, port=18814)
-thread = threading.Thread(target=lambda: server.start(threaded=False), daemon=True)
-thread.start()
-print("Blender IPC server started on port 18814")
+def start_blender_server():
+    """Start the DCC-MCP-IPC server inside Blender."""
+    server = create_dcc_server(
+        dcc_name="blender",
+        service_class=BlenderService,
+        port=BLENDER_IPC_PORT,
+    )
+    thread = threading.Thread(
+        target=lambda: server.start(threaded=False),
+        daemon=True,
+        name="dcc-mcp-ipc-blender",
+    )
+    thread.start()
+    print(f"[DCC-MCP-IPC] Blender server started on port {BLENDER_IPC_PORT}")
+    return server
+
+
+# Run when the script is executed inside Blender
+if __name__ == "__main__":
+    start_blender_server()
 ```
 
 ## Client
+
+Connect from any Python process outside Blender:
 
 ```python
 from dcc_mcp_ipc.client import BaseDCCClient
@@ -52,12 +149,118 @@ from dcc_mcp_ipc.client import BaseDCCClient
 client = BaseDCCClient("blender", host="localhost", port=18814)
 client.connect()
 
+# Query scene information
 info = client.call("get_scene_info")
-print(f"File: {info['file']}")
+print(f"File   : {info['file']}")
 print(f"Objects: {info['objects']}")
+print(f"Frame  : {info['frame_current']}")
 
-result = client.call("add_primitive", ptype="SPHERE", location=[1, 0, 0])
+# Add a sphere at (2, 0, 0)
+result = client.call("add_primitive", ptype="SPHERE", location=[2, 0, 0])
 print(f"Created: {result['name']}")
+
+# Move the object
+client.call("set_object_location", name=result["name"], location=[3, 1, 0])
+
+# Delete it
+client.call("delete_object", name=result["name"])
 
 client.disconnect()
 ```
+
+## Using the Action System
+
+Wrap Blender operations as typed Actions via `ActionAdapter`:
+
+```python
+from dcc_mcp_ipc.action_adapter import get_action_adapter
+from dcc_mcp_ipc.client import BaseDCCClient
+
+
+def create_blender_adapter(host="localhost", port=18814):
+    adapter = get_action_adapter("blender")
+    client = BaseDCCClient("blender", host=host, port=port)
+    client.connect()
+
+    def _get_scene_info() -> dict:
+        return client.call("get_scene_info")
+
+    def _add_primitive(ptype: str = "SPHERE", location: list = None) -> dict:
+        return client.call("add_primitive", ptype=ptype, location=location or [0, 0, 0])
+
+    adapter.register_action(
+        "blender_get_scene",
+        _get_scene_info,
+        description="Get current Blender scene metadata",
+        category="scene",
+        tags=["blender", "scene"],
+    )
+    adapter.register_action(
+        "blender_add_primitive",
+        _add_primitive,
+        description="Add a mesh primitive to the Blender scene",
+        category="modeling",
+        tags=["blender", "mesh", "primitive"],
+    )
+    return adapter, client
+
+
+adapter, client = create_blender_adapter()
+
+result = adapter.call_action("blender_get_scene")
+print(result.success, result.to_dict())
+
+result = adapter.call_action("blender_add_primitive", ptype="CUBE", location=[0, 0, 1])
+print(result.success, result.to_dict())
+
+client.disconnect()
+```
+
+## E2E Testing with MockDCCService
+
+For CI/CD pipelines where Blender is not available, use `MockDCCService` to simulate the Blender server:
+
+```python
+import pytest
+from dcc_mcp_ipc.testing.mock_services import MockDCCService
+from dcc_mcp_ipc.client import BaseDCCClient
+
+BLENDER_TEST_PORT = 18814
+
+
+@pytest.fixture(scope="module")
+def blender_server():
+    server = MockDCCService.start(port=BLENDER_TEST_PORT)
+    yield server
+    server.stop()
+
+
+@pytest.fixture
+def blender_client(blender_server):
+    client = BaseDCCClient("blender", host="localhost", port=BLENDER_TEST_PORT)
+    client.connect()
+    yield client
+    client.disconnect()
+
+
+def test_get_dcc_info(blender_client):
+    info = blender_client.get_dcc_info()
+    assert isinstance(info, dict)
+
+
+def test_connection_lifecycle(blender_server):
+    client = BaseDCCClient("blender", host="localhost", port=BLENDER_TEST_PORT)
+    client.connect()
+    assert client.is_connected()
+    client.disconnect()
+    assert not client.is_connected()
+```
+
+See [`tests/e2e/test_blender_ipc.py`](https://github.com/loonghao/dcc-mcp-ipc/blob/main/tests/e2e/test_blender_ipc.py) for the full E2E test suite.
+
+## Tips
+
+- **Port convention**: Blender uses port `18814` by convention. Maya uses `18812`, Houdini `18813`.
+- **Threading**: Always start the RPyC server in a daemon thread so Blender's event loop is not blocked.
+- **Service discovery**: Register the server with `ZeroConf` for automatic discovery by MCP clients on the same network.
+- **Security**: `exposed_execute_python` allows arbitrary code execution — restrict it to local development only.

--- a/logo.svg
+++ b/logo.svg
@@ -1,35 +1,102 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg width="200" height="200" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+<svg width="240" height="240" viewBox="0 0 240 240" xmlns="http://www.w3.org/2000/svg">
   <defs>
-    <linearGradient id="bg-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1E293B;stop-opacity:1" />
-      <stop offset="100%" style="stop-color:#0F172A;stop-opacity:1" />
+    <linearGradient id="bg-grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0D1B2A;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#1B2B3A;stop-opacity:1" />
     </linearGradient>
-    <linearGradient id="dcc-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#F97316;stop-opacity:1" />
-      <stop offset="33%" style="stop-color:#10B981;stop-opacity:1" />
-      <stop offset="66%" style="stop-color:#EF4444;stop-opacity:1" />
-      <stop offset="100%" style="stop-color:#8B5CF6;stop-opacity:1" />
+    <linearGradient id="ring-grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#00D4FF;stop-opacity:1" />
+      <stop offset="50%" style="stop-color:#7C3AED;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#F97316;stop-opacity:1" />
     </linearGradient>
-    <marker id="arrow" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
-      <path d="M0,0 L0,6 L9,3 z" fill="#3B82F6" />
-    </marker>
+    <linearGradient id="core-grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#00D4FF;stop-opacity:0.9" />
+      <stop offset="100%" style="stop-color:#7C3AED;stop-opacity:0.9" />
+    </linearGradient>
+    <linearGradient id="node-a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#F97316" />
+      <stop offset="100%" style="stop-color:#EF4444" />
+    </linearGradient>
+    <linearGradient id="node-b" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#10B981" />
+      <stop offset="100%" style="stop-color:#06B6D4" />
+    </linearGradient>
+    <linearGradient id="node-c" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#8B5CF6" />
+      <stop offset="100%" style="stop-color:#7C3AED" />
+    </linearGradient>
+    <filter id="glow" x="-30%" y="-30%" width="160%" height="160%">
+      <feGaussianBlur stdDeviation="3" result="coloredBlur"/>
+      <feMerge>
+        <feMergeNode in="coloredBlur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="2" stdDeviation="4" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
   </defs>
 
-  <!-- 背景 -->
-  <rect width="200" height="200" rx="24" fill="url(#bg-gradient)" />
+  <!-- Background rounded rect -->
+  <rect width="240" height="240" rx="28" fill="url(#bg-grad)" />
 
-  <!-- RPyC图形 -->
-  <circle cx="70" cy="100" r="28" fill="#3B82F6" />
-  <text x="70" y="105" font-family="Arial, sans-serif" font-weight="bold" font-size="14" text-anchor="middle" fill="white">RPyC</text>
+  <!-- Subtle grid lines -->
+  <g opacity="0.06" stroke="#00D4FF" stroke-width="0.5">
+    <line x1="0" y1="60" x2="240" y2="60"/>
+    <line x1="0" y1="120" x2="240" y2="120"/>
+    <line x1="0" y1="180" x2="240" y2="180"/>
+    <line x1="60" y1="0" x2="60" y2="240"/>
+    <line x1="120" y1="0" x2="120" y2="240"/>
+    <line x1="180" y1="0" x2="180" y2="240"/>
+  </g>
 
-  <!-- DCC图形 -->
-  <circle cx="140" cy="100" r="28" fill="url(#dcc-gradient)" />
-  <text x="140" y="105" font-family="Arial, sans-serif" font-weight="bold" font-size="14" text-anchor="middle" fill="white">DCC</text>
+  <!-- Outer decorative ring -->
+  <circle cx="120" cy="108" r="72" fill="none" stroke="url(#ring-grad)" stroke-width="1.5" stroke-dasharray="8 4" opacity="0.5"/>
 
-  <!-- 连接箭头 -->
-  <line x1="98" y1="100" x2="112" y2="100" stroke="#3B82F6" stroke-width="3" marker-end="url(#arrow)" />
+  <!-- Connection lines (DCC nodes to center) -->
+  <g stroke="#3B82F6" stroke-width="1.5" opacity="0.6" filter="url(#glow)">
+    <!-- Top left node to center -->
+    <line x1="72" y1="62" x2="107" y2="95"/>
+    <!-- Top right node to center -->
+    <line x1="168" y1="62" x2="133" y2="95"/>
+    <!-- Bottom node to center -->
+    <line x1="120" y1="158" x2="120" y2="128"/>
+  </g>
 
-  <!-- 项目名称 -->
-  <text x="100" y="170" font-family="Arial, sans-serif" font-weight="bold" font-size="16" text-anchor="middle" fill="white">DCC-MCP-RPyC</text>
+  <!-- DCC node: Blender (top left) -->
+  <g filter="url(#shadow)">
+    <circle cx="66" cy="56" r="22" fill="url(#node-a)" />
+    <text x="66" y="52" font-family="'Helvetica Neue', Arial, sans-serif" font-weight="700" font-size="8" text-anchor="middle" fill="white" letter-spacing="0.5">BLENDER</text>
+    <!-- Blender-like icon: triangle -->
+    <polygon points="66,58 59,68 73,68" fill="white" opacity="0.85"/>
+  </g>
+
+  <!-- DCC node: Maya (top right) -->
+  <g filter="url(#shadow)">
+    <circle cx="174" cy="56" r="22" fill="url(#node-b)" />
+    <text x="174" y="52" font-family="'Helvetica Neue', Arial, sans-serif" font-weight="700" font-size="8" text-anchor="middle" fill="white" letter-spacing="0.5">MAYA</text>
+    <!-- Maya-like icon: M shape -->
+    <text x="174" y="68" font-family="'Helvetica Neue', Arial, sans-serif" font-weight="900" font-size="14" text-anchor="middle" fill="white" opacity="0.85">M</text>
+  </g>
+
+  <!-- DCC node: Houdini (bottom) -->
+  <g filter="url(#shadow)">
+    <circle cx="120" cy="168" r="22" fill="url(#node-c)" />
+    <text x="120" y="164" font-family="'Helvetica Neue', Arial, sans-serif" font-weight="700" font-size="7.5" text-anchor="middle" fill="white" letter-spacing="0.5">HOUDINI</text>
+    <!-- Houdini-like icon: H -->
+    <text x="120" y="180" font-family="'Helvetica Neue', Arial, sans-serif" font-weight="900" font-size="14" text-anchor="middle" fill="white" opacity="0.85">H</text>
+  </g>
+
+  <!-- Central hub: MCP core -->
+  <g filter="url(#glow)">
+    <circle cx="120" cy="108" r="26" fill="url(#core-grad)" opacity="0.15"/>
+    <circle cx="120" cy="108" r="22" fill="#0D1B2A" stroke="url(#core-grad)" stroke-width="2"/>
+    <text x="120" y="105" font-family="'Helvetica Neue', Arial, sans-serif" font-weight="800" font-size="9" text-anchor="middle" fill="#00D4FF" letter-spacing="1">MCP</text>
+    <text x="120" y="117" font-family="'Helvetica Neue', Arial, sans-serif" font-weight="700" font-size="7" text-anchor="middle" fill="#7C3AED" letter-spacing="0.5">IPC</text>
+  </g>
+
+  <!-- Bottom label -->
+  <text x="120" y="212" font-family="'Helvetica Neue', Arial, sans-serif" font-weight="700" font-size="13" text-anchor="middle" fill="#CBD5E1" letter-spacing="2">DCC-MCP-IPC</text>
+  <text x="120" y="228" font-family="'Helvetica Neue', Arial, sans-serif" font-weight="400" font-size="8" text-anchor="middle" fill="#475569" letter-spacing="1">Multi-Protocol IPC Layer</text>
 </svg>

--- a/tests/e2e/__init__.py
+++ b/tests/e2e/__init__.py
@@ -1,0 +1,6 @@
+"""End-to-end tests for DCC-MCP-IPC.
+
+These tests verify the complete IPC communication pipeline using MockDCCService
+to simulate real DCC applications (Blender, Maya, Houdini) without requiring
+actual DCC installations.
+"""

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,0 +1,57 @@
+"""Shared fixtures for E2E tests.
+
+Provides lightweight server/client fixtures that simulate Blender, Maya, and
+Houdini IPC endpoints using MockDCCService — no real DCC install required.
+"""
+
+# Import built-in modules
+import threading
+import time
+
+# Import third-party modules
+import pytest
+from rpyc.utils.server import ThreadedServer
+
+# Import local modules
+from dcc_mcp_ipc.testing.mock_services import MockDCCService
+
+
+def _start_mock_server(dcc_name: str) -> tuple:
+    """Start a MockDCCService on a random port and return (server, port)."""
+    # Pass the service CLASS (not an instance) so RPyC creates one per connection
+    # and properly maps exposed_* methods via the default RPyC protocol.
+    server = ThreadedServer(
+        MockDCCService,
+        port=0,
+        protocol_config={"allow_public_attrs": True},
+        logger=None,
+    )
+    thread = threading.Thread(target=server.start, daemon=True, name=f"e2e-{dcc_name}")
+    thread.start()
+    # Give the server a moment to bind
+    time.sleep(0.15)
+    return server, server.port
+
+
+@pytest.fixture(scope="module")
+def blender_server():
+    """Module-scoped mock Blender IPC server on a random port."""
+    server, port = _start_mock_server("blender")
+    yield server, port
+    server.close()
+
+
+@pytest.fixture(scope="module")
+def maya_server():
+    """Module-scoped mock Maya IPC server on a random port."""
+    server, port = _start_mock_server("maya")
+    yield server, port
+    server.close()
+
+
+@pytest.fixture(scope="module")
+def houdini_server():
+    """Module-scoped mock Houdini IPC server on a random port."""
+    server, port = _start_mock_server("houdini")
+    yield server, port
+    server.close()

--- a/tests/e2e/test_blender_ipc.py
+++ b/tests/e2e/test_blender_ipc.py
@@ -1,0 +1,398 @@
+"""E2E tests for Blender MCP-IPC integration.
+
+These tests exercise the full IPC communication pipeline — server startup,
+client connection, RPC calls, action dispatch, and connection pool — using
+MockDCCService to simulate a running Blender instance.
+
+No Blender installation is required; the mock service faithfully implements
+the same RPyC protocol surface that a real Blender add-on would expose.
+"""
+
+# Import built-in modules
+import threading
+import time
+from typing import Any
+
+# Import third-party modules
+import pytest
+
+# Import local modules
+from dcc_mcp_ipc.action_adapter import get_action_adapter
+from dcc_mcp_ipc.client import BaseDCCClient
+from dcc_mcp_ipc.client import ConnectionPool
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def blender_client(blender_server):
+    """Function-scoped connected BaseDCCClient pointing at the mock Blender server."""
+    _, port = blender_server
+    client = BaseDCCClient("blender", host="localhost", port=port, auto_connect=False)
+    client.connect()
+    yield client
+    if client.is_connected():
+        client.disconnect()
+
+
+# ---------------------------------------------------------------------------
+# 1. Connection lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestConnectionLifecycle:
+    """Verify that the client can connect to and disconnect from the server."""
+
+    def test_connect_and_is_connected(self, blender_server):
+        _, port = blender_server
+        client = BaseDCCClient("blender", host="localhost", port=port, auto_connect=False)
+        client.connect()
+        assert client.is_connected(), "Client should report connected after connect()"
+        client.disconnect()
+
+    def test_disconnect_clears_connection(self, blender_server):
+        _, port = blender_server
+        client = BaseDCCClient("blender", host="localhost", port=port, auto_connect=False)
+        client.connect()
+        client.disconnect()
+        assert not client.is_connected(), "Client should not be connected after disconnect()"
+
+    def test_multiple_connect_disconnect_cycles(self, blender_server):
+        """Repeated connect/disconnect must not raise or corrupt state."""
+        _, port = blender_server
+        client = BaseDCCClient("blender", host="localhost", port=port, auto_connect=False)
+        for _ in range(3):
+            client.connect()
+            assert client.is_connected()
+            client.disconnect()
+            assert not client.is_connected()
+
+
+# ---------------------------------------------------------------------------
+# 2. DCC info retrieval
+# ---------------------------------------------------------------------------
+
+
+class TestDCCInfo:
+    """Verify that the client can retrieve DCC application metadata via IPC."""
+
+    def _get_dcc_info(self, client: BaseDCCClient) -> dict:
+        """Retrieve DCC info directly via exposed_ RPC method."""
+        return client.execute_with_connection(lambda conn: conn.root.exposed_get_dcc_info())
+
+    def test_get_dcc_info_returns_dict(self, blender_client):
+        info = self._get_dcc_info(blender_client)
+        assert isinstance(info, dict), "get_dcc_info() must return a dict"
+
+    def test_get_dcc_info_has_name(self, blender_client):
+        info = self._get_dcc_info(blender_client)
+        assert "name" in info, "DCC info must include 'name' key"
+
+    def test_get_dcc_info_has_version(self, blender_client):
+        info = self._get_dcc_info(blender_client)
+        assert "version" in info, "DCC info must include 'version' key"
+
+    def test_get_dcc_info_has_platform(self, blender_client):
+        info = self._get_dcc_info(blender_client)
+        assert "platform" in info, "DCC info must include 'platform' key"
+
+
+# ---------------------------------------------------------------------------
+# 3. Scene information
+# ---------------------------------------------------------------------------
+
+
+class TestSceneInfo:
+    """Verify scene metadata retrieval through the IPC channel."""
+
+    def test_get_scene_info_returns_dict(self, blender_client):
+        result = blender_client.get_scene_info()
+        assert isinstance(result, dict)
+
+    def test_get_scene_info_success_flag(self, blender_client):
+        result = blender_client.get_scene_info()
+        assert result.get("success") is True
+
+    def test_get_scene_info_has_context(self, blender_client):
+        result = blender_client.get_scene_info()
+        assert "context" in result, "Scene info result must contain a 'context' key"
+
+    def test_scene_context_has_objects(self, blender_client):
+        result = blender_client.get_scene_info()
+        ctx = result.get("context", {})
+        assert "objects" in ctx, "Scene context must list 'objects'"
+        assert isinstance(ctx["objects"], list)
+
+
+# ---------------------------------------------------------------------------
+# 4. Primitive creation (Blender-style actions)
+# ---------------------------------------------------------------------------
+
+
+class TestPrimitiveCreation:
+    """Verify that primitive-creation actions work end-to-end over IPC."""
+
+    @pytest.mark.parametrize("primitive_type", ["sphere", "cube"])
+    def test_create_supported_primitive(self, blender_client, primitive_type):
+        result = blender_client.create_primitive(primitive_type)
+        assert isinstance(result, dict)
+        assert result.get("success") is True, f"create_primitive({primitive_type!r}) failed: {result}"
+
+    def test_create_sphere_has_context_name(self, blender_client):
+        result = blender_client.create_primitive("sphere")
+        ctx = result.get("context", {})
+        assert "name" in ctx or "id" in ctx, "Sphere result context must include 'name' or 'id'"
+
+    def test_create_cube_has_context_name(self, blender_client):
+        result = blender_client.create_primitive("cube")
+        ctx = result.get("context", {})
+        assert "name" in ctx or "id" in ctx
+
+    def test_create_unknown_primitive_fails_gracefully(self, blender_client):
+        result = blender_client.create_primitive("torus_unknown")
+        assert isinstance(result, dict)
+        # Should report failure, not raise
+        assert result.get("success") is False
+
+
+# ---------------------------------------------------------------------------
+# 5. Echo / round-trip via execute_python
+# ---------------------------------------------------------------------------
+
+
+class TestRoundTrip:
+    """Basic round-trip tests via execute_python to verify bi-directional RPC."""
+
+    def test_execute_simple_expression(self, blender_client):
+        result = blender_client.execute_python("1 + 1")
+        assert result == 2
+
+    def test_execute_string_expression(self, blender_client):
+        result = blender_client.execute_python("'blender'.upper()")
+        assert result == "BLENDER"
+
+    def test_execute_arithmetic(self, blender_client):
+        result = blender_client.execute_python("7 * 8 - 6")
+        assert result == 50
+
+
+# ---------------------------------------------------------------------------
+# 6. Session info
+# ---------------------------------------------------------------------------
+
+
+class TestSessionInfo:
+    """Verify session metadata is correctly returned."""
+
+    def test_get_session_info_returns_dict(self, blender_client):
+        result = blender_client.get_session_info()
+        assert isinstance(result, dict)
+
+    def test_session_info_success(self, blender_client):
+        result = blender_client.get_session_info()
+        assert result.get("success") is True
+
+    def test_session_info_has_application(self, blender_client):
+        result = blender_client.get_session_info()
+        ctx = result.get("context", {})
+        assert "application" in ctx
+
+    def test_session_info_has_id(self, blender_client):
+        result = blender_client.get_session_info()
+        ctx = result.get("context", {})
+        assert "id" in ctx
+
+
+# ---------------------------------------------------------------------------
+# 7. Action adapter integration
+# ---------------------------------------------------------------------------
+
+
+class TestActionAdapterIntegration:
+    """Verify the ActionAdapter can register and dispatch Blender actions.
+
+    Note: ActionAdapter uses the Rust dcc-mcp-core backend which requires plain
+    Python dicts (not RPyC netrefs). These tests use local stub functions that
+    return plain dicts, simulating what a properly-written Blender action would
+    do after unwrapping the RPC response.
+    """
+
+    def test_register_and_call_blender_action(self, blender_server):
+        """Register a scene-query action and verify successful dispatch."""
+        _, port = blender_server
+        adapter = get_action_adapter("blender_e2e_scene")
+
+        # Use a plain-dict returning stub (Rust dispatcher requires real Python dicts)
+        # The ActionDispatcher may pass a positional context arg — accept *args to handle it
+        def _get_scene(*args, **kwargs) -> dict:
+            return {"scene": "blender_mock", "objects": ["Cube", "Sphere"], "frame": 1}
+
+        adapter.register_action(
+            "blender_e2e_get_scene",
+            _get_scene,
+            description="Fetch Blender scene info via mock IPC",
+            category="scene",
+            tags=["blender", "e2e"],
+        )
+
+        result = adapter.call_action("blender_e2e_get_scene")
+        assert result.success is True
+
+    def test_action_result_to_dict(self, blender_server):
+        """Verify ActionAdapter result serialises correctly to a plain dict."""
+        _, port = blender_server
+        adapter = get_action_adapter("blender_e2e_info_adapter")
+
+        def _get_dcc_info(**kwargs) -> dict:
+            return {"name": "blender", "version": "4.0", "platform": "win32"}
+
+        adapter.register_action("blender_e2e_get_info", _get_dcc_info, description="DCC info")
+        result = adapter.call_action("blender_e2e_get_info")
+        result_dict = result.to_dict()
+        assert isinstance(result_dict, dict)
+        assert "success" in result_dict
+
+    def test_action_for_primitive_creation(self, blender_server):
+        """Verify ActionAdapter dispatches to a Blender-style primitive creation function."""
+        _, port = blender_server
+        adapter = get_action_adapter("blender_e2e_prim_adapter")
+
+        def _create_sphere(radius: float = 1.0, **kwargs) -> dict:
+            return {"success": True, "name": f"Sphere_r{radius}", "type": "SPHERE"}
+
+        adapter.register_action(
+            "blender_e2e_create_sphere",
+            _create_sphere,
+            description="Create a sphere in Blender via mock IPC",
+            category="modeling",
+            tags=["blender", "mesh", "e2e"],
+        )
+
+        result = adapter.call_action("blender_e2e_create_sphere", radius=2.0)
+        assert result.success is True
+        result_dict = result.to_dict()
+        assert result_dict.get("success") is True
+
+    def test_action_ipc_round_trip(self, blender_server):
+        """End-to-end: register action, IPC call, verify client receives correct data."""
+        _, port = blender_server
+        client = BaseDCCClient("blender", host="localhost", port=port, auto_connect=False)
+        client.connect()
+
+        # Verify IPC round-trip independently of ActionAdapter
+        scene = client.get_scene_info()
+        assert scene.get("success") is True
+        assert "context" in scene
+
+        client.disconnect()
+
+
+# ---------------------------------------------------------------------------
+# 8. Connection pool
+# ---------------------------------------------------------------------------
+
+
+class TestConnectionPool:
+    """Verify that ConnectionPool manages Blender connections correctly."""
+
+    def test_pool_get_client_returns_connected_client(self, blender_server):
+        _, port = blender_server
+        pool = ConnectionPool()
+        client = pool.get_client("blender", host="localhost", port=port)
+        assert client.is_connected()
+        client.disconnect()
+
+    def test_pool_client_can_call_get_scene_info(self, blender_server):
+        _, port = blender_server
+        pool = ConnectionPool()
+        client = pool.get_client("blender", host="localhost", port=port)
+        info = client.get_scene_info()
+        assert isinstance(info, dict)
+        client.disconnect()
+
+
+# ---------------------------------------------------------------------------
+# 9. Concurrent connections
+# ---------------------------------------------------------------------------
+
+
+class TestConcurrentConnections:
+    """Verify that multiple clients can talk to the server simultaneously."""
+
+    def test_two_clients_simultaneously(self, blender_server):
+        _, port = blender_server
+        results: dict = {}
+        errors: dict = {}
+
+        def _worker(name: str) -> None:
+            try:
+                c = BaseDCCClient("blender", host="localhost", port=port, auto_connect=False)
+                c.connect()
+                # Use get_scene_info which is properly exposed
+                results[name] = c.get_scene_info()
+                c.disconnect()
+            except Exception as exc:
+                errors[name] = exc
+
+        threads = [threading.Thread(target=_worker, args=(f"client-{i}",)) for i in range(2)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=5)
+
+        assert not errors, f"Concurrent connection errors: {errors}"
+        assert len(results) == 2
+        for name, info in results.items():
+            assert isinstance(info, dict), f"{name} did not return a dict"
+
+    def test_five_clients_simultaneously(self, blender_server):
+        _, port = blender_server
+        results: dict = {}
+        errors: dict = {}
+
+        def _worker(idx: int) -> None:
+            name = f"client-{idx}"
+            try:
+                c = BaseDCCClient("blender", host="localhost", port=port, auto_connect=False)
+                c.connect()
+                results[name] = c.execute_python(str(idx))
+                c.disconnect()
+            except Exception as exc:
+                errors[name] = exc
+
+        threads = [threading.Thread(target=_worker, args=(i,)) for i in range(5)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        assert not errors, f"Concurrent errors: {errors}"
+        for i in range(5):
+            assert results[f"client-{i}"] == i
+
+
+# ---------------------------------------------------------------------------
+# 10. Available actions listing
+# ---------------------------------------------------------------------------
+
+
+class TestAvailableActions:
+    """Verify that the server exposes its available actions."""
+
+    def test_get_actions_returns_dict(self, blender_client):
+        result = blender_client.execute_with_connection(lambda conn: conn.root.exposed_get_actions())
+        assert isinstance(result, dict)
+        assert "actions" in result
+
+    def test_get_actions_includes_create_primitive(self, blender_client):
+        result = blender_client.execute_with_connection(lambda conn: conn.root.exposed_get_actions())
+        actions = result.get("actions", {})
+        assert "create_primitive" in actions
+
+    def test_get_actions_includes_get_scene_info(self, blender_client):
+        result = blender_client.execute_with_connection(lambda conn: conn.root.exposed_get_actions())
+        actions = result.get("actions", {})
+        assert "get_scene_info" in actions


### PR DESCRIPTION
## Summary

- **New logo**: Modern hub-and-node SVG design — Blender/Maya/Houdini nodes orbiting the MCP IPC core, replaces the old two-circle design
- **README refresh**: Cleaner header (logo + badge row + nav links), Blender-first quick-start examples, updated project structure showing `tests/e2e/`, identical content in both `README.md` and `README_zh.md`
- **Expanded Blender docs** (`docs/examples/blender.md`): Full add-on server with 6 primitive types, `ActionAdapter` integration pattern, E2E testing section linking to the new test file
- **Blender E2E test suite** (`tests/e2e/`): 34 pytest tests using `MockDCCService` — no real Blender required

## Test coverage added

| Group | Tests |
|-------|-------|
| Connection lifecycle | connect / disconnect / repeated cycles |
| DCC info | name, version, platform |
| Scene info | success flag, context shape, objects list |
| Primitive creation | sphere, cube, unknown type (graceful failure) |
| Round-trip / `execute_python` | arithmetic, string expressions |
| Session info | success, application, id |
| ActionAdapter integration | register + dispatch, `to_dict()`, primitive action, IPC round-trip |
| ConnectionPool | returns connected client, can call RPC |
| Concurrent connections | 2 clients, 5 clients simultaneously |
| Available actions | listing, `create_primitive`, `get_scene_info` |

## Test plan

- [x] All 34 new E2E tests pass (`pytest tests/e2e/`)
- [x] Existing 933 tests unaffected (`pytest tests/ --ignore=tests/e2e`)
- [ ] Visual review of new logo in GitHub README preview
- [ ] Docs site builds without errors (`npm run docs:build` in `docs/`)